### PR TITLE
Stopping bicep build in main branch post merge

### DIFF
--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -48,10 +48,20 @@ jobs:
 
       - name: Git diff
         shell: pwsh
+        id: isGitDiff
         run: |
-          git diff --shortstat
+          $diff=git diff --shortstat
+          
+          if ($null -eq $diff) {
+            echo "::set-output name=GITDIFF::false" #outputting for condition
+          }
+          else {
+            echo "::set-output name=GITDIFF::true" #outputting for condition
+          }
+          
           
       - name: GIT Push Json file
+        if: ${{ steps.isGitDiff.outputs.GITDIFF}}
         uses: actions-x/commit@v2
         with:
           message: Adding auto compiled bicep json

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -66,7 +66,7 @@ jobs:
           echo "gitdiff is ${{ steps.isGitDiff.outputs.GITDIFF}}"
           
       - name: GIT Push Json file
-        if: ${{ steps.isGitDiff.outputs.GITDIFF}}
+        if: steps.isGitDiff.outputs.GITDIFF==true
         uses: actions-x/commit@v2
         with:
           message: Adding auto compiled bicep json

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -7,6 +7,10 @@ on:
     paths: 
       - 'bicep/*'
       - ".github/workflows/bicepBuild.yml"
+    branches-ignore: main
+    
+  pull_request:
+    branches: main
 
   workflow_dispatch:
   

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
   
 jobs:
-  build:
+  Validation:
     runs-on: ubuntu-latest
   
     steps:
@@ -50,8 +50,6 @@ jobs:
         shell: pwsh
         run: |
           git diff --shortstat
-
-
           
       - name: GIT Push Json file
         uses: actions-x/commit@v2

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -57,7 +57,7 @@ jobs:
             echo "::set-output name=GITDIFF::false" #outputting for condition
           }
           else {
-            write-output "No difference in compiled bicep to commit"
+            write-output "There are differences in compiled bicep to commit"
             echo "::set-output name=GITDIFF::true" #outputting for condition
           }
           

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -53,12 +53,17 @@ jobs:
           $diff=git diff --shortstat
           
           if ($null -eq $diff) {
+            write-output "No difference in compiled bicep to commit"
             echo "::set-output name=GITDIFF::false" #outputting for condition
           }
           else {
+            write-output "No difference in compiled bicep to commit"
             echo "::set-output name=GITDIFF::true" #outputting for condition
           }
           
+      - name: Debug
+        run: |
+          echo "gitdiff is ${{ steps.isGitDiff.outputs.GITDIFF}}"
           
       - name: GIT Push Json file
         if: ${{ steps.isGitDiff.outputs.GITDIFF}}

--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -46,11 +46,12 @@ jobs:
 
           /home/runner/.azure/bin/bicep build bicep/main.bicep --outdir $compiledir
 
-      - name: ContextCheck
+      - name: Git diff
         shell: pwsh
         run: |
-          cd bicep/compiled
-          dir
+          git diff --shortstat
+
+
           
       - name: GIT Push Json file
         uses: actions-x/commit@v2

--- a/bicep/compiled/main.json
+++ b/bicep/compiled/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "5512021043181041758"
+      "templateHash": "15343024568483163339"
     }
   },
   "parameters": {
@@ -2201,6 +2201,10 @@
     "keyVaultName": {
       "type": "string",
       "value": "[if(parameters('createKV'), variables('akvName'), '')]"
+    },
+    "keyVaultId": {
+      "type": "string",
+      "value": "[if(parameters('createKV'), resourceId('Microsoft.KeyVault/vaults', variables('akvName')), '')]"
     },
     "containerRegistryName": {
       "type": "string",


### PR DESCRIPTION
## PR Summary

We've added protection to the main branch, but this action workflow is triggered post PR and attempting to push to main.

It should instead run as Push in branches, and as part of PR, and not on push to main.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue #109 
