### PR TITLE
updated stale action to work as intended.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,3 +26,7 @@ jobs:
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
         days-before-stale: 20
+        days-before-close: 7
+        remove-stale-when-updated: true
+        labels-to-remove-when-unstale: 'stale'
+        labels-to-add-when-unstale: 'Keep Open'


### PR DESCRIPTION
## PR Summary

Closes #124

Updated the Stale action to:

- Remove stale label when a stale issue is updated, and adds a new 'Keep open' label
- Close issue if still stale 7 days after stale label added

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [X] Link to a filed issue
