### PR TITLE
Adding containerRegistryId output

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -321,6 +321,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' = if (!
   }
 }
 output containerRegistryName string = !empty(registries_sku) ? acr.name : ''
+output containerRegistryId string = !empty(registries_sku) ? acr.id : ''
 
 resource acrDiags 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (createLaw && !empty(registries_sku)) {
   name: 'acrDiags'


### PR DESCRIPTION
## PR Summary

Adding containerRegistryId to outputs of the acr resource.
Rationale is that this Id can then be reused if creating a private endpoint for the container registry.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [] Link to a filed issue
