### PR TITLE
Changing default K8S version

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -738,7 +738,7 @@ output ApplicationGatewayName string = deployAppGw ? appgw.name : ''
 param dnsPrefix string = '${resourceName}-dns'
 
 @description('Kubernetes Version')
-param kubernetesVersion string = '1.20.9'
+param kubernetesVersion string = '1.21.7'
 
 @description('Enable Azure AD integration on AKS')
 param enable_aad bool = false

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -8,7 +8,7 @@
     },
     "defaults": {
         "deploy": {
-            "kubernetesVersion": "1.20.9",
+            "kubernetesVersion": "1.21.7",
             "location": "WestEurope",
             "apiips": "",
             "demoapp": false,


### PR DESCRIPTION
## PR Summary

The Azure Portal has updated the default Kubernetes Version
![image](https://user-images.githubusercontent.com/17914476/147404763-1f7b1456-71ca-4768-b648-b915d3213dc0.png)

For consistency with the Portal defaults, bumping our K8S version.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
