### PR TITLE
Preventing forks from initiating workflows that use secrets

### DIFF
--- a/.github/workflows/ByoVnetCI.yml
+++ b/.github/workflows/ByoVnetCI.yml
@@ -81,6 +81,7 @@ jobs:
   Validation:
     runs-on: ubuntu-latest
     environment: azurecirgs
+    if: ${{ !github.event.pull_request.head.repo.fork }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -72,6 +72,8 @@ jobs:
 
   Validation:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/StandardCI.yml
+++ b/.github/workflows/StandardCI.yml
@@ -33,6 +33,8 @@ env:
 jobs:
   Validation:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+
     steps:
       #Get the code files from the repo
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ Various workflows run on Push / PR / Schedule.
 
 Each has a *Validate job*, that is required to pass before merging to main. PR's tagged with `bug`, that contain changes to bicep or workflow files will need to pass all of the jobs in the relevant workflows before merge is possible.
 
+### PR's from Forks
+
+If you're creating a PR from a fork then we're unable to run the typical actions to ensure quality that the core team are able to use. This is because GitHub prevents Forks from leveraging secrets in this repository. PR's from forks will therefore require comprehensive checking from the core team before merging.
+
+> If you are making any changes to the bicep files, then we require you run the `bicep build workflow` in your repo, and include the resulting compiled bicep in your PR.
+
 ## Branches
 
 ### Feature Branch


### PR DESCRIPTION
## PR Summary

GitHub action workflows cannot access secrets in this repo. We need to stop them being triggered from forked PR's.

Closes #160 
Closes #109

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
