### PR TITLE
Bumping preview repo tag references to proper tag ref

### DIFF
--- a/.github/workflows/AppDeploy_JavaApp.yml
+++ b/.github/workflows/AppDeploy_JavaApp.yml
@@ -1,7 +1,7 @@
 # This file is now been transferred to a new repository.
-# https://github.com/Azure-Samples/java-aks-keyvault-tls/blob/0.9-preview/.github/workflows/deployapp.yml
+# https://github.com/Azure-Samples/java-aks-keyvault-tls/blob/0.9/.github/workflows/deployapp.yml
 # Retarget any workflows to use the it instead of this one.
-# eg. uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9-preview
+# eg. uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9
 
 on:
   workflow_call:

--- a/.github/workflows/ByoVnetCI.yml
+++ b/.github/workflows/ByoVnetCI.yml
@@ -492,7 +492,7 @@ jobs:
         run:
           AKSNAME='${{ steps.deployAks.outputs.AKSNAME}}'
 
-          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3-preview/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
+          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
           echo "Sending command $netpolicycmd to $AKSNAME in $RG";
           cmdOut=$(az aks command invoke -g $RG -n $AKSNAME -o json --command "${netpolicycmd}");
           echo $cmdOut;
@@ -523,7 +523,7 @@ jobs:
 
   Post-Deploy:
     needs: [Deploy, ReusableWF]
-    uses: azure/aks-construction/.github/workflows/PostDeploy.yml@gb-certmanagerrefactor
+    uses: azure/aks-construction/.github/workflows/PostDeploy.yml@0.4.3
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }}
       AKSNAME: ${{needs.Deploy.outputs.AKSNAME}}

--- a/.github/workflows/ByoVnetCI.yml
+++ b/.github/workflows/ByoVnetCI.yml
@@ -550,7 +550,7 @@ jobs:
   SmokeTest_JavaApp-certmgr:
     needs: [Deploy, ReusableWF, Post-Deploy]
     #uses: azure/aks-construction/.github/workflows/AppDeploy_JavaApp.yml@0.4.2-preview
-    uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9-preview
+    uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       AKSNAME: ${{needs.Deploy.outputs.AKSNAME}}
@@ -569,7 +569,7 @@ jobs:
   SmokeTest_JavaApp-appgw:
     needs: [Deploy, ReusableWF, Post-Deploy, SmokeTest_JavaApp-certmgr]
     #uses: azure/aks-construction/.github/workflows/AppDeploy_JavaApp.yml@0.4.2-preview
-    uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9-preview
+    uses: azure-samples/java-aks-keyvault-tls/.github/workflows/deployapp.yml@0.9
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       AKSNAME: ${{needs.Deploy.outputs.AKSNAME}}

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -239,7 +239,7 @@ jobs:
         run:
           AKSNAME='${{ steps.deployAks.outputs.AKSNAME}}'
 
-          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3-preview/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
+          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
           echo "Sending command $netpolicycmd to $AKSNAME in $RG";
           cmdOut=$(az aks command invoke -g $RG -n $AKSNAME -o json --command "${netpolicycmd}");
           echo $cmdOut;
@@ -269,7 +269,7 @@ jobs:
   SmokeTest_KnownGoodApp:
     needs: [ReusableWF, Deploy]
     #This points to a specific branch, because of a limitation around targetting @${{ github.sha }} isn't supported yet. https://github.community/t/ref-head-in-reusable-workflows/203690/6
-    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.2-preview
+    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.3
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }}
       AKSNAME: ${{ needs.Deploy.outputs.AKSNAME}}

--- a/.github/workflows/Test_ReusableWorkflows.yml
+++ b/.github/workflows/Test_ReusableWorkflows.yml
@@ -29,7 +29,7 @@ jobs:
 
   Post-Deploy:
     needs: [ReusableWF]
-    uses: azure/aks-construction/.github/workflows/PostDeploy.yml@gb-certmanagerrefactor
+    uses: azure/aks-construction/.github/workflows/PostDeploy.yml@0.4.3
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }}
       AKSNAME: aks-Byo
@@ -42,7 +42,7 @@ jobs:
   byo-cluster:
     if: false
     needs: [ReusableWF]
-    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.2-preview
+    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.3
     with:
       RG: ${{ needs.ReusableWF.outputs.RG }}
       AKSNAME: aks-Byo
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create Default Deny NetworkPolicy
         run:
-          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3-preview/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
+          netpolicycmd="kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3/postdeploy/k8smanifests/networkpolicy-deny-all.yml";
 
           if [ -z "$netpolicycmd" ];
           then
@@ -151,7 +151,7 @@ jobs:
   deploy-azure-vote-app-lb:
     #needs: test-run-cmd
     if: false
-    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.2-preview
+    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.3
     with:
       RG: Automation-Actions-AksDeployCI #$RG
       AKSNAME: aks-Byo
@@ -167,7 +167,7 @@ jobs:
   deploy-azure-vote-app-ing:
     #needs: test-run-cmd
     if: false
-    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.2-preview
+    uses: azure/aks-construction/.github/workflows/AppDeploy_AzureVote.yml@0.4.3
     with:
       RG: Automation-Actions-AksDeployCI
       AKSNAME: aks-Priva

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 env:
-  templateRelease: 0.4.0-preview
+  templateRelease: 0.4.3
   AZCLIVERSION: 2.30.0 #2.29.2 #2.26.0 #latest
   RG: "Automation-Actions-AksPublishCI"
 

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -154,7 +154,7 @@ ${cluster.apisecurity === "private" ? `"` : ``}
 # -----------------------------------
 # Create a default-deny network policy in your cluster to deny all traffic in the default namespace
 ${cluster.apisecurity === "private" ? `az aks command invoke -g ${deploy.rg} -n ${aks}  --command "` : ``}
-kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3-preview/postdeploy/k8smanifests/networkpolicy-deny-all.yml
+kubectl apply -f https://raw.githubusercontent.com/Azure/Aks-Construction/0.4.3/postdeploy/k8smanifests/networkpolicy-deny-all.yml
 ${cluster.apisecurity === "private" ? `"` : ``}
 ` : '') +
 


### PR DESCRIPTION
## PR Summary

Some of the workflows were pointing to an old tag or in 2 of the cases, to an old branch 😢 
This PR references the proper 0.4.3 release tag.

It also points to the full 0.9 release in the[ Azure-Samples java app repo](https://github.com/Azure-Samples/java-aks-keyvault-tls/releases/tag/0.9).

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
