### PR TITLE
Remove 'preview' flag on Azure Key Vault with CSI secrets store provider

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -187,7 +187,7 @@ module dnsZone './dnsZone.bicep' = if (!empty(dnsZoneId)) {
 |__|\__\ |_______|    |__|            \__/ /__/     \__\ \______/  |_______|    |__|     */
 
 @description('Installs the AKS KV CSI provider')
-param azureKeyvaultSecretsProvider bool = false //This is a preview feature
+param azureKeyvaultSecretsProvider bool = false
 
 @description('Creates a Key Vault')
 param createKV bool = false

--- a/helper/src/components/addonsTab.js
+++ b/helper/src/components/addonsTab.js
@@ -275,7 +275,7 @@ export default function ({ tabValues, updateFn, invalidArray }) {
 
             <Stack.Item align="start">
                 <Label required={true}>
-                    CSI Secrets : Store Kubernetes Secrets in Azure KeyVault, using AKS Managed Identity (**Preview)
+                    CSI Secrets : Store Kubernetes Secrets in Azure KeyVault, using AKS Managed Identity
                     (<a target="_new" href="https://docs.microsoft.com/en-us/azure/aks/csi-secrets-store-driver">docs</a>)
                 </Label>
                 <ChoiceGroup


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and complete the checklist with 'x' between the brackets -->

Hi,

this is a very small change to remove the 'preview' flag seen in the deploy helper as this has changed in the docs via [this commit](https://github.com/MicrosoftDocs/azure-docs/commit/942c8efe4859c08ec6ce8a86f2587dd328c41346#diff-f6aa65f3842440a7aa2021aa66911111304199c77401ea33ddeea3cfe243d0a9R12) 

and releases have reached 1.0 for both of these
-  https://github.com/Azure/secrets-store-csi-driver-provider-azure/
-  https://github.com/kubernetes-sigs/secrets-store-csi-driver

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
