### PR TITLE
Stop forks from attempting regression tests (#credentials)

### DIFF
--- a/.github/workflows/regressionparams.yml
+++ b/.github/workflows/regressionparams.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   GetParamFiles:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     name: Get Param File List
     outputs:
       FILELIST: ${{ steps.getfiles.outputs.FILELIST}}


### PR DESCRIPTION
## PR Summary

Need to stop this workflow from being used when the PR source is a fork.
Forks can't leverage the credentials to automatically validate.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
