### PR TITLE
Bumping UI release to use 0.5

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 env:
-  templateRelease: 0.4.5
+  templateRelease: 0.5
   AZCLIVERSION: 2.30.0 #2.29.2 #2.26.0 #latest
   RG: "Automation-Actions-AksPublishCI"
 


### PR DESCRIPTION
## PR Summary

Moving the UI to Release 0.5 (OpenServiceMesh)

We really need a better way of bumping the UI releases that doing these changes 😢 

## PR Checklist

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
