### PR TITLE
Release Web App Automation

### DIFF
--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/download-artifact@v3
+        with:
+          name: testdoesthisthrowerror
+          path: testdoesthisthrowerror
+
       - name: Build node app with bicep release
         run: |
           cd helper

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -107,7 +107,7 @@ jobs:
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages-canary
-          commit_message: Deploy to Canary Github pages
+          commit_message: Pages Release. Canary ${{env.templateRelease}}
           build_dir: wizardapp
           keep_history: true
         env:
@@ -137,6 +137,7 @@ jobs:
         uses: crazy-max/ghaction-github-pages@v2
         with:
           target_branch: gh-pages
+          commit_message: Pages Release. Prod ${{env.templateRelease}}
           build_dir: wizardapp
           keep_history: true
         env:

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -124,7 +124,8 @@ jobs:
       - name: Deploy to GitHub Pages Prod
         uses: crazy-max/ghaction-github-pages@v2
         with:
-          target_branch: gh-pages-fake-prod
+          target_branch: gh-pages
           build_dir: wizardapp
+          keep_history: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check that the GitHub release doesn't already exist
         run: |
-          GHJSON=$(gh release view ${{env.templateRelease}} --json name)
+          GHJSON=$(gh release view ${{env.templateRelease}} --json name) || GHJSON=""
 
           if [ -z "$GHJSON" ]
           then

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -43,7 +43,15 @@ jobs:
 
       - name: Check that the GitHub release doesn't already exist
         run: |
-          echo "TODO: Abort if release tag already exists"
+          GHJSON=$(gh release view ${{env.templateRelease}} --json name)
+
+          if [ -z "$GHJSON" ]
+          then
+                echo "Release not found - great"
+          else
+                echo "Release already exists - aborting"
+                exit 1
+          fi
 
       - name: Install Bicep
         shell: pwsh

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -22,11 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v3
-        with:
-          name: testdoesthisthrowerror
-          path: testdoesthisthrowerror
-
       - name: Build node app with bicep release
         run: |
           cd helper

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Job Parameter Checking
+        run: |
+          echo "GitHub Ref: ${{ github.ref }}"
+
       - name: Build node app with bicep release
         run: |
           cd helper
@@ -88,7 +92,7 @@ jobs:
   DeployWebAppToCanary:
     runs-on: ubuntu-latest
     name: Deploy Web App to Canary Pages
-    if: ${{ always() }}
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
     needs: [BuildWebApp , CreateRelease]
     steps:
       - uses: actions/download-artifact@v3
@@ -117,7 +121,7 @@ jobs:
   DeployWebAppToProd:
     runs-on: ubuntu-latest
     name: Deploy Web App to Prod Pages
-    if: ${{ always() }}
+    if: ${{ always() && github.ref == 'refs/heads/main'}}
     environment: UI-Deploy-Manual-Approval
     needs: [BuildWebApp , CreateRelease, DeployWebAppToCanary]
     steps:

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Check that the GitHub release doesn't already exist
+        run: |
+          echo "TODO: Abort if release tag already exists"
+
       - name: Install Bicep
         shell: pwsh
         run: az bicep install
@@ -69,12 +73,20 @@ jobs:
 
   DeployWebApp:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs: [BuildWebApp , CreateRelease]
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: WizardApp
           path: wizardapp
+
+      #Although we don't need this artifact, if it's missing then we can abort this job
+      - uses: actions/download-artifact@v3
+        if: ${{ github.event.inputs.createRelease == 'true' }}
+        with:
+          name: CompiledBicep
+          path: compilebicep
 
       - name: Deploy to GitHub Pages
         uses: crazy-max/ghaction-github-pages@v2

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -35,7 +35,7 @@ jobs:
 
   CreateRelease:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.createRelease }}
+    if: ${{ github.event.inputs.createRelease == 'true' }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -52,6 +52,8 @@ jobs:
                 echo "Release already exists - aborting"
                 exit 1
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Bicep
         shell: pwsh

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -92,7 +92,7 @@ jobs:
   DeployWebAppToCanary:
     runs-on: ubuntu-latest
     name: Deploy Web App to Canary Pages
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    if: ${{ always() }}
     needs: [BuildWebApp , CreateRelease]
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       createRelease:
-        description: 'Build the bicep and create a NEW GitHub release'
+        description: 'Create a NEW release with that tag'
         type: boolean
         required: false
 
@@ -81,7 +81,9 @@ jobs:
 
       - name: Create GitHub release
         run: |
-          echo "TODO: Use GitHub CLI to create release"
+          GHJSON=$(gh release create ${{env.templateRelease}} 'bicep/compiled/main.json' -p --generate-notes )
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   DeployWebAppToCanary:
     runs-on: ubuntu-latest

--- a/.github/workflows/ghpages-release.yml
+++ b/.github/workflows/ghpages-release.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   BuildWebApp:
     runs-on: ubuntu-latest
+    name: Build Web App
     steps:
       - uses: actions/checkout@v2
 
@@ -35,6 +36,7 @@ jobs:
 
   CreateRelease:
     runs-on: ubuntu-latest
+    name: Create GitHub Release (bicep)
     if: ${{ github.event.inputs.createRelease == 'true' }}
     steps:
       - uses: actions/checkout@v2
@@ -71,8 +73,9 @@ jobs:
         run: |
           echo "TODO: Use GitHub CLI to create release"
 
-  DeployWebApp:
+  DeployWebAppToCanary:
     runs-on: ubuntu-latest
+    name: Deploy Web App to Canary Pages
     if: ${{ always() }}
     needs: [BuildWebApp , CreateRelease]
     steps:
@@ -88,10 +91,40 @@ jobs:
           name: CompiledBicep
           path: compilebicep
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages Canary
         uses: crazy-max/ghaction-github-pages@v2
         with:
-          target_branch: gh-pages-test
+          target_branch: gh-pages-canary
+          commit_message: Deploy to Canary Github pages
+          build_dir: wizardapp
+          keep_history: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  DeployWebAppToProd:
+    runs-on: ubuntu-latest
+    name: Deploy Web App to Prod Pages
+    if: ${{ always() }}
+    environment: UI-Deploy-Manual-Approval
+    needs: [BuildWebApp , CreateRelease, DeployWebAppToCanary]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: WizardApp
+          path: wizardapp
+
+      #Although we don't need this artifact, if it's missing then we can abort this job
+      - uses: actions/download-artifact@v3
+        if: ${{ github.event.inputs.createRelease == 'true' }}
+        with:
+          name: CompiledBicep
+          path: compilebicep
+
+      - name: Deploy to GitHub Pages Prod
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages-fake-prod
           build_dir: wizardapp
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Summary

This is the 2nd part of #215 

A manual release can now be triggered that can either;

1. Create a NEW release, with release notes, build the web app and deploy the web app
2. Build and deploy the web app targeting an EXISTING release

Additionally the deploy to GH pages settings have been changed so that a force push is not being used any longer. It'll be much easily rollback from inside the branch if we needed to revert.

The "prod" GitHub pages is protected with `environment approvals`, and a deployment will only be possible if triggered on the `main branch` (releasable code) and if the previous jobs run and artefacts generate **successfully**.

![image](https://user-images.githubusercontent.com/17914476/158432082-0ad816f7-d085-455f-813b-db638f92783b.png)

![image](https://user-images.githubusercontent.com/17914476/158487775-1cc9af89-dc65-4555-aa76-f2240a8fc8e9.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
Closes #215 