### PR TITLE
Sample: Adding taints/labels to extra node pools

### DIFF
--- a/bicep/aksagentpool.bicep
+++ b/bicep/aksagentpool.bicep
@@ -27,6 +27,9 @@ param maxPods int = 30
 @description('Any taints that should be applied to the node pool')
 param nodeTaints array = []
 
+@description('Any labels that should be applied to the node pool')
+param nodeLabels object = {}
+
 @description('The subnet the node pool will use')
 param subnetId string
 
@@ -55,5 +58,6 @@ resource nodepool 'Microsoft.ContainerService/managedClusters/agentPools@2021-10
       maxSurge: '33%'
     }
     nodeTaints: nodeTaints
+    nodeLabels: nodeLabels
   }
 }

--- a/bicep/aksagentpool.bicep
+++ b/bicep/aksagentpool.bicep
@@ -24,6 +24,10 @@ var autoScale = agentCountMax > agentCount
 @description('The maximum number of pods per node.')
 param maxPods int = 30
 
+@description('Any taints that should be applied to the node pool')
+param nodeTaints array = []
+
+@description('The subnet the node pool will use')
 param subnetId string
 
 resource aks 'Microsoft.ContainerService/managedClusters@2021-10-01' existing = {
@@ -50,5 +54,6 @@ resource nodepool 'Microsoft.ContainerService/managedClusters/agentPools@2021-10
     upgradeSettings: {
       maxSurge: '33%'
     }
+    nodeTaints: nodeTaints
   }
 }

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -881,6 +881,26 @@ param SystemPoolType string = 'Cost-Optimised'
 @description('A custom system pool spec')
 param SystemPoolCustomPreset object = {}
 
+param AutoscaleProfile object = {
+  'balance-similar-node-groups': 'true'
+  'expander': 'random'
+  'max-empty-bulk-delete': '10'
+  'max-graceful-termination-sec': '600'
+  'max-node-provision-time': '15m'
+  'max-total-unready-percentage': '45'
+  'new-pod-scale-up-delay': '0s'
+  'ok-total-unready-count': '3'
+  'scale-down-delay-after-add': '10m'
+  'scale-down-delay-after-delete': '20s'
+  'scale-down-delay-after-failure': '3m'
+  'scale-down-unneeded-time': '10m'
+  'scale-down-unready-time': '20m'
+  'scale-down-utilization-threshold': '0.5'
+  'scan-interval': '10s'
+  'skip-nodes-with-local-storage': 'true'
+  'skip-nodes-with-system-pods': 'true'
+}
+
 @description('System Pool presets are derived from the recommended system pool specs')
 var systemPoolPresets = {
   'Cost-Optimised' : {
@@ -1052,25 +1072,7 @@ var aksProperties = {
     upgradeChannel: upgradeChannel
   } : {}
   addonProfiles: !empty(aks_addons1) ? aks_addons1 : aks_addons
-  autoScalerProfile: autoScale ? {
-      'balance-similar-node-groups': 'true'
-      'expander': 'random'
-      'max-empty-bulk-delete': '10'
-      'max-graceful-termination-sec': '600'
-      'max-node-provision-time': '15m'
-      'max-total-unready-percentage': '45'
-      'new-pod-scale-up-delay': '0s'
-      'ok-total-unready-count': '3'
-      'scale-down-delay-after-add': '10m'
-      'scale-down-delay-after-delete': '20s'
-      'scale-down-delay-after-failure': '3m'
-      'scale-down-unneeded-time': '10m'
-      'scale-down-unready-time': '20m'
-      'scale-down-utilization-threshold': '0.5'
-      'scan-interval': '10s'
-      'skip-nodes-with-local-storage': 'true'
-      'skip-nodes-with-system-pods': 'true'
-  } : {}
+  autoScalerProfile: autoScale ? AutoscaleProfile : {}
 }
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS/issues/2774')

--- a/samples/peered-vnet/main.bicep
+++ b/samples/peered-vnet/main.bicep
@@ -75,6 +75,26 @@ module extrasubnet 'extrasubnet.bicep' = {
   }
 }
 
+var aggressiveAutoScaler ={
+  'balance-similar-node-groups': 'true'
+  'expander': 'random'
+  'max-empty-bulk-delete': '10'
+  'max-graceful-termination-sec': '200'
+  'max-node-provision-time': '15m'
+  'max-total-unready-percentage': '45'
+  'new-pod-scale-up-delay': '0s'
+  'ok-total-unready-count': '5'
+  'scale-down-delay-after-add': '1m'
+  'scale-down-delay-after-delete': '20s'
+  'scale-down-delay-after-failure': '3m'
+  'scale-down-unneeded-time': '1m'
+  'scale-down-unready-time': '2m'
+  'scale-down-utilization-threshold': '0.5'
+  'scan-interval': '10s'
+  'skip-nodes-with-local-storage': 'true'
+  'skip-nodes-with-system-pods': 'true'
+}
+
 //Deploy AKS clusters
 module gridAks '../../bicep/main.bicep' = {
   name: 'seleniumGridCluster'
@@ -95,6 +115,8 @@ module gridAks '../../bicep/main.bicep' = {
     JustUseSystemPool: false
     SystemPoolType: 'Cost-Optimised'
     byoAKSSubnetId: gridVnet.outputs.aksSubnetId
+    AutoscaleProfile: aggressiveAutoScaler
+    //agentVMTaints:  [for pool in extraAksNodePools: '${nodeTaintKey}=${pool}:NoExecute']
   }
 }
 
@@ -141,8 +163,11 @@ module aksNodePools '../../bicep/aksagentpool.bicep'  = [for pool in extraAksNod
     agentVMSize: 'Standard_B2s'
     maxPods: 10
     osDiskType: 'Managed'
-    nodeTaints: [
-      '${nodeTaintKey}=${pool}:${nodeTaintEffect}'
-    ]
+    // nodeTaints: [
+    //   '${nodeTaintKey}=${pool}:${nodeTaintEffect}'
+    // ]
+    nodeLabels:{
+      '${nodeTaintKey}' : '${pool}'
+    }
   }
 }]

--- a/samples/peered-vnet/main.bicep
+++ b/samples/peered-vnet/main.bicep
@@ -123,8 +123,11 @@ module appAks '../../bicep/main.bicep' = {
 var extraAksNodePools = [
   'chromepool'
   'firefoxpool'
+  'edgepool'
 ]
 
+param nodeTaintEffect string = 'NoSchedule'
+var nodeTaintKey = 'selbrowser'
 @batchSize(1) //Need to set this to avoid this concurrent update issue - 'Conflict. Status: Failed. Error: ResourceDeploymentFailure. The resource operation completed with terminal provisioning state 'Failed'
 module aksNodePools '../../bicep/aksagentpool.bicep'  = [for pool in extraAksNodePools:  {
   name: pool
@@ -139,7 +142,7 @@ module aksNodePools '../../bicep/aksagentpool.bicep'  = [for pool in extraAksNod
     maxPods: 10
     osDiskType: 'Managed'
     nodeTaints: [
-      'selbrowser=${pool}:PreferNoSchedule'
+      '${nodeTaintKey}=${pool}:${nodeTaintEffect}'
     ]
   }
 }]

--- a/samples/peered-vnet/main.bicep
+++ b/samples/peered-vnet/main.bicep
@@ -134,9 +134,12 @@ module aksNodePools '../../bicep/aksagentpool.bicep'  = [for pool in extraAksNod
     PoolName: pool
     subnetId: gridVnet.outputs.aksSubnetId
     agentCount: 0
-    agentCountMax: 3
+    agentCountMax: 10
     agentVMSize: 'Standard_B2s'
     maxPods: 10
     osDiskType: 'Managed'
+    nodeTaints: [
+      'selbrowser=${pool}:PreferNoSchedule'
+    ]
   }
 }]


### PR DESCRIPTION
## PR Summary

Rev'ing the peered vnet sample with the ability to taint the additional node pools.

This will help showcase scaling from zero better
![image](https://user-images.githubusercontent.com/17914476/159259075-2b6005a5-b49a-40d5-87bc-3ac72905abbf.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
