### PR TITLE
AZ CLI version - output issue at 2.37.0

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -42,10 +42,10 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(net.vnet_opt === "byo" && addons.ingress === 'appgw' && { byoAGWSubnetId: net.byoAGWSubnetId }),
     ...(cluster.enable_aad && { enable_aad: true, ...(cluster.enableAzureRBAC === false && cluster.aad_tenant_id && { aad_tenant_id: cluster.aad_tenant_id }) }),
     ...(cluster.enable_aad && cluster.AksDisableLocalAccounts !== defaults.cluster.AksDisableLocalAccounts && { AksDisableLocalAccounts: cluster.AksDisableLocalAccounts }),
-    ...(cluster.enable_aad && cluster.enableAzureRBAC && { enableAzureRBAC: true, ...(deploy.clusterAdminRole && { adminPrincipalId: "$(az ad signed-in-user show --query objectId --out tsv)" }) }),
+    ...(cluster.enable_aad && cluster.enableAzureRBAC && { enableAzureRBAC: true, ...(deploy.clusterAdminRole && { adminPrincipalId: "$(az ad signed-in-user show --query id --out tsv)" }) }),
     ...(addons.registry !== "none" && {
         registries_sku: addons.registry,
-        ...(deploy.acrPushRole && { acrPushRolePrincipalId: "$(az ad signed-in-user show --query objectId --out tsv)"}) }),
+        ...(deploy.acrPushRole && { acrPushRolePrincipalId: "$(az ad signed-in-user show --query id --out tsv)"}) }),
     ...(net.afw && { azureFirewalls: true, ...(addons.certMan && {certManagerFW: true}), ...(net.vnet_opt === "custom" && defaults.net.vnetFirewallSubnetAddressPrefix !== net.vnetFirewallSubnetAddressPrefix && { vnetFirewallSubnetAddressPrefix: net.vnetFirewallSubnetAddressPrefix }) }),
     ...(net.vnet_opt === "custom" && net.vnetprivateend && {
         privateLinks: true,
@@ -75,7 +75,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
       })
     }),
     ...(addons.csisecret !== "none" && { azureKeyvaultSecretsProvider: true }),
-    ...(addons.csisecret === 'akvNew' && { createKV: true, ...(deploy.kvCertSecretRole && { kvOfficerRolePrincipalId: "$(az ad signed-in-user show --query objectId --out tsv)"}) })
+    ...(addons.csisecret === 'akvNew' && { createKV: true, ...(deploy.kvCertSecretRole && { kvOfficerRolePrincipalId: "$(az ad signed-in-user show --query id --out tsv)"}) })
   }
 
   const preview_params = {
@@ -466,7 +466,7 @@ ${postscript_cluster.replaceAll('"', '\\"')}
             <Stack.Item>
               <Label >Commands to deploy your fully operational environment</Label>
               <Text>
-                Requires <Link target="_bl" href="https://docs.microsoft.com/cli/azure/install-azure-cli">AZ CLI</Link>, or, execute in the
+                Requires <Link target="_bl" href="https://docs.microsoft.com/cli/azure/install-azure-cli">AZ CLI (2.37.0 or greater)</Link>, or, execute in the
                 <Link target="_cs" href="http://shell.azure.com/">Azure Cloud Shell</Link>.
 
               </Text>

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -466,9 +466,7 @@ ${postscript_cluster.replaceAll('"', '\\"')}
             <Stack.Item>
               <Label >Commands to deploy your fully operational environment</Label>
               <Text>
-                Requires <Link target="_bl" href="https://docs.microsoft.com/cli/azure/install-azure-cli">AZ CLI (2.37.0 or greater)</Link>, or, execute in the
-                <Link target="_cs" href="http://shell.azure.com/">Azure Cloud Shell</Link>.
-
+                Requires <Link target="_bl" href="https://docs.microsoft.com/cli/azure/install-azure-cli">AZ CLI (2.37.0 or greater)</Link>, or execute in the <Link target="_cs" href="http://shell.azure.com/">Azure Cloud Shell</Link>.
               </Text>
             </Stack.Item>
 


### PR DESCRIPTION
## PR Summary

Closes #297 

Fixes an issue with the output from the az cli when getting the users currently signed in objectid.
This issue was introduced in the AZ CLI (2.37.0) (May 24th release) when it migrated to the Microsoft Graph API for the `az ad` commands.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
