### PR TITLE
Extra Deploy Helper release testing

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.REACT_APP_TEMPLATERELEASE }}
-      doAzCmdDeployment: ${{ github.event.inputs.doAzCmdDeployment }}
+      doAzCmdDeployment: ${{ github.event.inputs.doAzCmdDeployment == 'true' }}
     steps:
       - name: Reusable workflow
         run: |

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.REACT_APP_TEMPLATERELEASE }}
-      doAzCmdDeployment: ${{ github.event.inputs.doAzCmdDeployment == 'true' }}
+      doAzCmdDeployment: ${{ github.event.inputs.doAzCmdDeployment }}
     steps:
       - name: Reusable workflow
         run: |
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/ghpagesTest.yml
     with:
       REACT_APP_TEMPLATERELEASE: ${{ needs.SetupWF.outputs.REACT_APP_TEMPLATERELEASE }}
-      doAzCmdDeployment: ${{ needs.SetupWF.outputs.doAzCmdDeployment }}
+      doAzCmdDeployment: ${{ needs.SetupWF.outputs.doAzCmdDeployment == 'true' }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -11,6 +11,11 @@ on:
 
   workflow_dispatch:
     inputs:
+      REACT_APP_TEMPLATERELEASE:
+        required: false
+        type: string
+        default: ''
+        description: 'Test against an older release tag? (Provided the tag)'
       doAzCmdDeployment:
         description: 'Test AZ Cmd by deploying to an Azure subscription'
         default: false
@@ -18,10 +23,24 @@ on:
         required: false
 
 jobs:
+  SetupWF:
+    runs-on: ubuntu-latest
+    outputs:
+      REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.REACT_APP_TEMPLATERELEASE }}
+      doAzCmdDeployment: ${{ github.event.inputs.doAzCmdDeployment }}
+    steps:
+      - name: Reusable workflow
+        run: |
+          echo "Resuable workflows can't be directly passed ENV/INPUTS (yet)"
+          echo "So we need this job to be able to access the value in env.RG"
+          echo "see https://github.community/t/reusable-workflow-env-context-not-available-in-jobs-job-id-with/206111"
+
   Validation:
+    needs: [SetupWF]
     uses: ./.github/workflows/ghpagesTest.yml
     with:
-      REACT_APP_TEMPLATERELEASE: "" #Null value means to just test on main branch (local) not a release tag
+      REACT_APP_TEMPLATERELEASE: ${{ needs.SetupWF.outputs.REACT_APP_TEMPLATERELEASE }}
+      doAzCmdDeployment: ${{ needs.SetupWF.outputs.doAzCmdDeployment }}
     secrets:
       AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -17,12 +17,15 @@ on:
         type: boolean
         required: false
 
-env:
-  AZCLIVERSION: 2.34.1 #2.29.2 #2.26.0 #latest
-  RG: "Automation-Actions-AksPublishCI"
-
 jobs:
   Validation:
+    uses: ./.github/workflows/ghpagesTest.yml
+    with:
+      REACT_APP_TEMPLATERELEASE: "" #Null value means to just test on main branch (local) not a release tag
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+
+  Spelling:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -37,150 +40,3 @@ jobs:
           files: "**/*.{ts,js,md}" #You need to respecify this setting - even though it's in the cspell.json config :(
           incremental_files_only: false
           strict: true #setting to false allows the build to continue even if spelling mistakes are detected
-
-      - name: Build and start node app
-        run: |
-          cd helper
-          npm install
-          npm run build
-          npm run start&
-
-      - name: Playwright - Install w/ OS dependencies
-        run: |
-          cd helper
-          npx playwright install #https://github.com/microsoft/playwright/issues/4033
-          npx playwright install-deps chromium
-          npm i -D playwright-expect
-
-      - name: Test web server is up
-        run: curl http://localhost:3000/AKS-Construction
-
-      - name: Verifying Playwright install
-        run: |
-          cd helper
-
-          echo "Looking for playwright"
-          ls node_modules | grep playwright
-
-          echo "Playwright version"
-          npx playwright -V
-
-      - name: File system prep
-        run: |
-          mkdir failscreengrabs
-          mkdir alwaysscreengrabs
-
-      - name: Playwright - Run fragile helper tests
-        env:
-          filenamewordmatch: 'helper-fragile'
-        continue-on-error: true
-        run: |
-          cd helper
-          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --reporter dot
-
-      - name: Playwright - Run stable helper tests
-        env:
-          filenamewordmatch: 'helper-test'
-          filenamewordexclude: 'fragile'
-        run: |
-          cd helper
-          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --grep-invert '${{ env.filenamewordexclude }}' --reporter list
-
-      - name: Playwright - Grab Az Commands
-        env:
-          filenamewordmatch: 'helper-export'
-        run: |
-          cd helper
-          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --reporter list
-
-      - name: Persist exported Az Commands for visibility
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: AzCmds
-          path: helper/azcmd-*.sh
-
-      - name: Install Bicep
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        shell: pwsh
-        run: |
-          az bicep install
-
-      - name: Bicep build
-        if: ${{ github.event.pull_request.head.repo.fork }}
-        shell: pwsh
-        run: |
-          #write-output $pwd
-          $compiledir=Join-Path -Path $pwd -ChildPath "bicep/compiled"
-
-          write-output $compiledir
-          If(!(test-path $compiledir))
-          {
-                New-Item -ItemType Directory -Force -Path $compiledir
-          }
-
-          /home/runner/.azure/bin/bicep build ./bicep/main.bicep --outdir $compiledir
-
-      - name: Azure Login
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: Azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-          enable-AzPSSession: true
-          environment: azurecloud
-
-      #TODO: If/When we capture more AZ CMD's, then we'll want to iterate over files beginning with "azcmd"
-      - name: Verify AZ Commands
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: Azure/cli@v1.0.6
-        env:
-          azcmdpath: "helper/azcmd-managed-private.sh"
-        with:
-          azcliversion: ${{ env.AZCLIVERSION }}
-          inlineScript: |
-            #Change the Create to a Validate statement
-            sed -i 's/az deployment group create/az deployment group validate/' $azcmdpath
-
-            #Remove lines that refer to signed-in-user which don't work with a SP.
-            sed -i '/az ad signed-in-user show/d' $azcmdpath
-
-            #Debug
-            cat $azcmdpath
-
-            #Run the script
-            echo "Running the validation script"
-            sh $azcmdpath
-
-      - name: Full deploy test AZ Commands
-        if: ${{ !github.event.pull_request.head.repo.fork && ( github.event.inputs.doAzCmdDeployment == 'true' || contains( github.event.pull_request.labels.*.name, 'test-deploy-wizard')) }}
-        uses: Azure/cli@v1.0.6
-        env:
-          azcmdpath: "helper/azcmd-managed-private.sh"
-        with:
-          azcliversion: ${{ env.AZCLIVERSION }}
-          inlineScript: |
-            #Change the Create to a Validate statement
-            sed -i 's/az deployment group validate/az deployment group create --mode Complete --name ghpages/' $azcmdpath
-
-            #Debug
-            cat $azcmdpath
-
-            #Run the script
-            sh $azcmdpath
-
-            #Cleanup
-            #az deploymentg group delete -n ghpages  -g $RG
-
-      - name: Persist test failure screengrabs as artifacts
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: TestFailScreengrabs
-          path: helper/failscreengrabs/*.png
-
-      - name: Persist always screengrabs as artifacts
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: Screengrabs
-          path: helper/alwaysscreengrabs/*.png

--- a/.github/workflows/ghpagesTest.yml
+++ b/.github/workflows/ghpagesTest.yml
@@ -42,7 +42,7 @@ jobs:
           npm run build
           npm run start&
 
-      - name: Build and start node app (targeting bicep release tag)
+      - name: Build and start node app (targeting Bicep release tag)
         if: inputs.REACT_APP_TEMPLATERELEASE != ''
         run: |
           cd helper

--- a/.github/workflows/ghpagesTest.yml
+++ b/.github/workflows/ghpagesTest.yml
@@ -12,11 +12,15 @@ on:
       REACT_APP_TEMPLATERELEASE:
         required: false
         type: string
-        default: ""
+        default: ''
       RG:
         required: false
         type: string
         default: "Automation-Actions-AksPublishCI"
+      doAzCmdDeployment:
+        required: false
+        type: boolean
+        default: true
     secrets:
       AZURE_CREDENTIALS:
         required: true
@@ -31,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build and start node app
-        if: inputs.REACT_APP_TEMPLATERELEASE == ""
+        if: inputs.REACT_APP_TEMPLATERELEASE == ''
         run: |
           cd helper
           npm install
@@ -39,7 +43,7 @@ jobs:
           npm run start&
 
       - name: Build node app with bicep release
-        if: inputs.REACT_APP_TEMPLATERELEASE != ""
+        if: inputs.REACT_APP_TEMPLATERELEASE != ''
         run: |
           cd helper
           npm install
@@ -153,7 +157,7 @@ jobs:
             sh $azcmdpath
 
       - name: Full deploy test AZ Commands
-        if: ${{ !github.event.pull_request.head.repo.fork && ( github.event.inputs.doAzCmdDeployment == 'true' || contains( github.event.pull_request.labels.*.name, 'test-deploy-wizard')) }}
+        if: ${{ !github.event.pull_request.head.repo.fork && ( inputs.doAzCmdDeployment == 'true' || contains( github.event.pull_request.labels.*.name, 'test-deploy-wizard')) }}
         uses: Azure/cli@v1.0.6
         env:
           azcmdpath: "helper/azcmd-managed-private.sh"

--- a/.github/workflows/ghpagesTest.yml
+++ b/.github/workflows/ghpagesTest.yml
@@ -1,0 +1,187 @@
+#Takes the source code from main and validates that it will
+#1. Pass Playwright UI tests
+#2. Results in a successful deployment to Azure
+#
+#As an optional parameter, an existing release TAG can be provided which helps test for breaking changes for slip-releases
+
+name: Deploy Helper - Validate
+
+on:
+  workflow_call:
+    inputs:
+      REACT_APP_TEMPLATERELEASE:
+        required: false
+        type: string
+        default: ""
+      RG:
+        required: false
+        type: string
+        default: "Automation-Actions-AksPublishCI"
+    secrets:
+      AZURE_CREDENTIALS:
+        required: true
+
+env:
+  AZCLIVERSION: 2.34.1 #2.29.2 #2.26.0 #latest
+
+jobs:
+  Validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and start node app
+        if: inputs.REACT_APP_TEMPLATERELEASE == ""
+        run: |
+          cd helper
+          npm install
+          npm run build
+          npm run start&
+
+      - name: Build node app with bicep release
+        if: inputs.REACT_APP_TEMPLATERELEASE != ""
+        run: |
+          cd helper
+          npm install
+          REACT_APP_TEMPLATERELEASE="${{inputs.REACT_APP_TEMPLATERELEASE}}"  npm run build
+          npm run start&
+
+      - name: Playwright - Install w/ OS dependencies
+        run: |
+          cd helper
+          npx playwright install #https://github.com/microsoft/playwright/issues/4033
+          npx playwright install-deps chromium
+          npm i -D playwright-expect
+
+      - name: Test web server is up
+        run: curl http://localhost:3000/AKS-Construction
+
+      - name: Verifying Playwright install
+        run: |
+          cd helper
+
+          echo "Looking for playwright"
+          ls node_modules | grep playwright
+
+          echo "Playwright version"
+          npx playwright -V
+
+      - name: File system prep
+        run: |
+          mkdir failscreengrabs
+          mkdir alwaysscreengrabs
+
+      - name: Playwright - Run fragile helper tests
+        env:
+          filenamewordmatch: 'helper-fragile'
+        continue-on-error: true
+        run: |
+          cd helper
+          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --reporter dot
+
+      - name: Playwright - Run stable helper tests
+        env:
+          filenamewordmatch: 'helper-test'
+          filenamewordexclude: 'fragile'
+        run: |
+          cd helper
+          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --grep-invert '${{ env.filenamewordexclude }}' --reporter list
+
+      - name: Playwright - Grab Az Commands
+        env:
+          filenamewordmatch: 'helper-export'
+        run: |
+          cd helper
+          npx playwright test --browser chromium .playwrighttests/ -g '${{ env.filenamewordmatch }}' --reporter list
+
+      - name: Persist exported Az Commands for visibility
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: AzCmds
+          path: helper/azcmd-*.sh
+
+      - name: Install Bicep
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        shell: pwsh
+        run: |
+          az bicep install
+
+      - name: Bicep build
+        if: ${{ github.event.pull_request.head.repo.fork }}
+        shell: pwsh
+        run: |
+          #write-output $pwd
+          $compiledir=Join-Path -Path $pwd -ChildPath "bicep/compiled"
+
+          write-output $compiledir
+          If(!(test-path $compiledir))
+          {
+                New-Item -ItemType Directory -Force -Path $compiledir
+          }
+
+          /home/runner/.azure/bin/bicep build ./bicep/main.bicep --outdir $compiledir
+
+      - name: Azure Login
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          enable-AzPSSession: true
+          environment: azurecloud
+
+      #TODO: If/When we capture more AZ CMD's, then we'll want to iterate over files beginning with "azcmd"
+      - name: Verify AZ Commands
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        uses: Azure/cli@v1.0.6
+        env:
+          azcmdpath: "helper/azcmd-managed-private.sh"
+        with:
+          azcliversion: ${{ env.AZCLIVERSION }}
+          inlineScript: |
+            #Change the Create to a Validate statement
+            sed -i 's/az deployment group create/az deployment group validate/' $azcmdpath
+
+            #Remove lines that refer to signed-in-user which don't work with a SP.
+            sed -i '/az ad signed-in-user show/d' $azcmdpath
+
+            #Debug
+            cat $azcmdpath
+
+            #Run the script
+            echo "Running the validation script"
+            sh $azcmdpath
+
+      - name: Full deploy test AZ Commands
+        if: ${{ !github.event.pull_request.head.repo.fork && ( github.event.inputs.doAzCmdDeployment == 'true' || contains( github.event.pull_request.labels.*.name, 'test-deploy-wizard')) }}
+        uses: Azure/cli@v1.0.6
+        env:
+          azcmdpath: "helper/azcmd-managed-private.sh"
+        with:
+          azcliversion: ${{ env.AZCLIVERSION }}
+          inlineScript: |
+            #Change the Create to a Validate statement
+            sed -i 's/az deployment group validate/az deployment group create --mode Complete --name ghpages/' $azcmdpath
+
+            #Debug
+            cat $azcmdpath
+
+            #Run the script
+            sh $azcmdpath
+
+            #Cleanup
+            #az deploymentg group delete -n ghpages  -g $RG
+
+      - name: Persist test failure screengrabs as artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: TestFailScreengrabs
+          path: helper/failscreengrabs/*.png
+
+      - name: Persist always screengrabs as artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Screengrabs
+          path: helper/alwaysscreengrabs/*.png

--- a/.github/workflows/ghpagesTest.yml
+++ b/.github/workflows/ghpagesTest.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build and start node app
+      - name: Build and start node app (targeting Bicep in MAIN)
         if: inputs.REACT_APP_TEMPLATERELEASE == ''
         run: |
           cd helper
@@ -42,13 +42,12 @@ jobs:
           npm run build
           npm run start&
 
-      - name: Build node app with bicep release
+      - name: Build and start node app (targeting bicep release tag)
         if: inputs.REACT_APP_TEMPLATERELEASE != ''
         run: |
           cd helper
           npm install
-          REACT_APP_TEMPLATERELEASE="${{inputs.REACT_APP_TEMPLATERELEASE}}"  npm run build
-          npm run start&
+          REACT_APP_TEMPLATERELEASE="${{inputs.REACT_APP_TEMPLATERELEASE}}" npm run start&
 
       - name: Playwright - Install w/ OS dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,25 @@ env:
   templateRelease: ${{ github.event.inputs.templateRelease }}
 
 jobs:
+  SetupWF:
+    runs-on: ubuntu-latest
+    outputs:
+      REACT_APP_TEMPLATERELEASE: ${{ env.REACT_APP_TEMPLATERELEASE }}
+    steps:
+      - name: Reusable workflow
+        run: |
+          echo "Resuable workflows can't be directly passed ENV/INPUTS (yet)"
+          echo "So we need this job to be able to access the value in env.RG"
+          echo "see https://github.community/t/reusable-workflow-env-context-not-available-in-jobs-job-id-with/206111"
+  TestWebApp:
+    needs: [SetupWF]
+    uses: ./.github/workflows/ghpagesTest.yml
+    if:  ${{ github.event.inputs.createRelease == false }}
+    with:
+      REACT_APP_TEMPLATERELEASE: ${{ needs.SetupWF.outputs.REACT_APP_TEMPLATERELEASE }}
+      doAzCmdDeployment: true
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
   BuildWebApp:
     runs-on: ubuntu-latest
     name: Build Web App

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,16 @@ jobs:
   SetupWF:
     runs-on: ubuntu-latest
     outputs:
-      REACT_APP_TEMPLATERELEASE: ${{ env.REACT_APP_TEMPLATERELEASE }}
+      REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.templateRelease }}
     steps:
       - name: Reusable workflow
         run: |
           echo "Resuable workflows can't be directly passed ENV/INPUTS (yet)"
           echo "So we need this job to be able to access the value in env.RG"
           echo "see https://github.community/t/reusable-workflow-env-context-not-available-in-jobs-job-id-with/206111"
+      - name: Param checking
+        run: |
+          echo "Targetting Template Release ${{github.event.inputs.templateRelease}}"
   TestWebApp:
     needs: [SetupWF]
     uses: ./.github/workflows/ghpagesTest.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   TestWebApp:
     needs: [SetupWF]
     uses: ./.github/workflows/ghpagesTest.yml
-    if:  ${{ github.event.inputs.createRelease == false }}
+    if:  ${{ github.event.inputs.createRelease == 'false' }}
     with:
       REACT_APP_TEMPLATERELEASE: ${{ needs.SetupWF.outputs.REACT_APP_TEMPLATERELEASE }}
       doAzCmdDeployment: true


### PR DESCRIPTION
## PR Summary

Closes #338 

There was a Deploy Helper release edge case, whereby you could do a "UI Release only" if what you were releasing didn't have any breaking changes between the latest release and what was in main.

Unfortunately, we got bitten by this by a UI release between 0.8.7 and 0.8.8

This PR adds a new testing step which **prevents a release** of the UI beyond canary if the test suites don't pass.

![image](https://user-images.githubusercontent.com/17914476/181757454-977e6209-42f2-432a-b810-de54e75e14da.png)


## PR Details

Predominantly this PR is just a simple refactor of testing code we already had into a reusable workflow. The new reusable workflow is called from the workflow file it was taken from but now **also from the Release workflow**.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
