### PR TITLE
Add support for enabling the Dapr extension

### DIFF
--- a/.github/workflows_dep/regressionparams/dapr.json
+++ b/.github/workflows_dep/regressionparams/dapr.json
@@ -8,7 +8,10 @@
         "agentVMSize": {
             "value": "Standard_DS3_v2"
         },
-        "fluxGitOpsAddon": {
+        "daprAddon": {
+            "value": true
+        },
+        "daprAddonHA": {
             "value": true
         }
     }

--- a/.github/workflows_dep/regressionparams/dapr.json
+++ b/.github/workflows_dep/regressionparams/dapr.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceName": {
+            "value": "az-k8s-dapr"
+        },
+        "agentVMSize": {
+            "value": "Standard_DS3_v2"
+        },
+        "fluxGitOpsAddon": {
+            "value": true
+        }
+    }
+}

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1183,8 +1183,10 @@ resource fluxAddon 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-prev
 }
 output fluxReleaseNamespace string = fluxGitOpsAddon ? fluxAddon.properties.scope.cluster.releaseNamespace : ''
 
+@description('Add the Dapr extension')
 param daprAddon bool = false
-param daprAddon_enableHighAvailability bool = false
+@description('Enable high availability (HA) mode for the Dapr control plane')
+param daprAddonHA bool = false
 
 resource daprExtension 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-preview' = if(daprAddon) {
     name: 'dapr'
@@ -1194,7 +1196,7 @@ resource daprExtension 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-
         autoUpgradeMinorVersion: true
         releaseTrain: 'Stable'
         configurationSettings: {
-            'global.ha.enabled': daprAddon_enableHighAvailability ? 'true' : 'false'
+            'global.ha.enabled': '${daprAddonHA}'
         }
         scope: {
           cluster: {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1183,6 +1183,30 @@ resource fluxAddon 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-prev
 }
 output fluxReleaseNamespace string = fluxGitOpsAddon ? fluxAddon.properties.scope.cluster.releaseNamespace : ''
 
+param daprAddon bool = false
+param daprAddon_enableHighAvailability bool = false
+
+resource daprExtension 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-preview' = if(daprAddon) {
+    name: 'dapr'
+    scope: aks
+    properties: {
+        extensionType: 'Microsoft.Dapr'
+        autoUpgradeMinorVersion: true
+        releaseTrain: 'Stable'
+        configurationSettings: {
+            'global.ha.enabled': daprAddon_enableHighAvailability ? 'true' : 'false'
+        }
+        scope: {
+          cluster: {
+            releaseNamespace: 'dapr-system'
+          }
+        }
+        configurationProtectedSettings: {}
+    }
+}
+
+output daprReleaseNamespace string = daprAddon ? daprExtension.properties.scope.cluster.releaseNamespace : ''
+
 
 /*__  ___.   ______   .__   __.  __  .___________.  ______   .______       __  .__   __.   _______
 |   \/   |  /  __  \  |  \ |  | |  | |           | /  __  \  |   _  \     |  | |  \ |  |  /  _____|

--- a/cspell.json
+++ b/cspell.json
@@ -41,6 +41,7 @@
         "currenttab",
         "currt",
         "currv",
+        "dapr",
         "Daemonset",
         "demoapp",
         "denydefault",

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,7 @@
         "currt",
         "currv",
         "dapr",
+        "Dapr",
         "Daemonset",
         "demoapp",
         "denydefault",

--- a/helper/src/components/addonsTab.js
+++ b/helper/src/components/addonsTab.js
@@ -405,8 +405,8 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                     disabled={!addons.daprAddon}
                     styles={{ root: { marginLeft: "50px" } }}
                     inputProps={{ "data-testid": "addons-dapr-ha-checkbox" }}
-                    checked={addons.daprAddon_enableHighAvailability}
-                    onChange={(ev, v) => updateFn("daprAddon_enableHighAvailability", v)}
+                    checked={addons.daprAddonHA}
+                    onChange={(ev, v) => updateFn("daprAddonHA", v)}
                     label="Enable high availability mode"
                 />
             </Stack.Item>

--- a/helper/src/components/addonsTab.js
+++ b/helper/src/components/addonsTab.js
@@ -384,8 +384,32 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
 
             </Stack.Item>
 
-        </Stack >
+            <Separator className="notopmargin" />
 
-
-    )
+            <Stack.Item align="start">
+                <Label required={true}>
+                    dapr (Distributed Application Runtime)
+                    (<a target="_new" href="https://docs.microsoft.com/en-us/azure/aks/dapr">docs</a>)
+                </Label>
+                <MessageBar messageBarType={MessageBarType.info} styles={{ root: { marginBottom: "10px" } }}>
+                    Enabling this option installs dapr, but doesn't apply configuration
+                </MessageBar>
+                <Checkbox
+                    styles={{ root: { marginLeft: "50px" } }}
+                    inputProps={{ "data-testid": "addons-dapr-checkbox" }}
+                    checked={addons.daprAddon}
+                    onChange={(ev, v) => updateFn("daprAddon", v)}
+                    label="Install the Dapr AddOn"
+                />
+                <Checkbox
+                    disabled={!addons.daprAddon}
+                    styles={{ root: { marginLeft: "50px" } }}
+                    inputProps={{ "data-testid": "addons-dapr-ha-checkbox" }}
+                    checked={addons.daprAddon_enableHighAvailability}
+                    onChange={(ev, v) => updateFn("daprAddon_enableHighAvailability", v)}
+                    label="Enable high availability mode"
+                />
+            </Stack.Item>
+        </Stack>
+    );
 }

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -88,7 +88,8 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(addons.csisecret !== "none" && { keyVaultAksCSI: true }),
     ...(addons.csisecret === 'akvNew' && { keyVaultCreate: true, ...(deploy.kvCertSecretRole && { keyVaultOfficerRolePrincipalId: "$(az ad signed-in-user show --query id --out tsv)"}) }),
     ...(addons.csisecret !== "none" && addons.keyVaultAksCSIPollInterval !== defaults.addons.keyVaultAksCSIPollInterval  && { keyVaultAksCSIPollInterval: addons.keyVaultAksCSIPollInterval }),
-    ...(addons.fluxGitOpsAddon !== defaults.addons.fluxGitOpsAddon && { fluxGitOpsAddon: addons.fluxGitOpsAddon})
+    ...(addons.fluxGitOpsAddon !== defaults.addons.fluxGitOpsAddon && { fluxGitOpsAddon: addons.fluxGitOpsAddon}),
+    ...(addons.daprAddon !== defaults.addons.daprAddon && { daprAddon: addons.daprAddon }),
   }
 
   const preview_params = {

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -90,6 +90,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(addons.csisecret !== "none" && addons.keyVaultAksCSIPollInterval !== defaults.addons.keyVaultAksCSIPollInterval  && { keyVaultAksCSIPollInterval: addons.keyVaultAksCSIPollInterval }),
     ...(addons.fluxGitOpsAddon !== defaults.addons.fluxGitOpsAddon && { fluxGitOpsAddon: addons.fluxGitOpsAddon}),
     ...(addons.daprAddon !== defaults.addons.daprAddon && { daprAddon: addons.daprAddon }),
+    ...(addons.daprAddonHA !== defaults.addons.daprAddonHA && { daprAddonHA: addons.daprAddonHA }),
   }
 
   const preview_params = {

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -51,7 +51,7 @@
         },
         "addons": {
             "daprAddon": false,
-            "daprAddon_enableHighAvailability": false,
+            "daprAddonHA": false,
             "fluxGitOpsAddon": false,
             "networkPolicy": "none",
             "kedaAddon": false,

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -50,6 +50,8 @@
             "DefenderForContainers" : false
         },
         "addons": {
+            "daprAddon": false,
+            "daprAddon_enableHighAvailability": false,
             "fluxGitOpsAddon": false,
             "networkPolicy": "none",
             "kedaAddon": false,


### PR DESCRIPTION
Signed-off-by: Janusz Dziurzynski <janusz@corechain.tech>

## PR Summary

This adds two checkboxes to the addons page: one for enabling the Dapr extension, and one for enabling HA mode (with the default HA settings). Partly addresses  #304 

![CleanShot 2022-08-11 at 18 53 40](https://user-images.githubusercontent.com/3941539/184255769-e93dbe5d-2c83-4fbc-863d-e631658cc4c8.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
