### PR TITLE
Fixing Dapr + Flux race condition

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -718,7 +718,6 @@ param kedaAddon bool = false
 param openServiceMeshAddon bool = false
 
 @allowed([
-  ''
   'none'
   'patch'
   'stable'
@@ -726,7 +725,7 @@ param openServiceMeshAddon bool = false
   'node-image'
 ])
 @description('AKS upgrade channel')
-param upgradeChannel string = ''
+param upgradeChannel string = 'none'
 
 @allowed([
   'Ephemeral'
@@ -1083,9 +1082,7 @@ var aksProperties = union({
     outboundType: aksOutboundTrafficType
   }
   disableLocalAccounts: AksDisableLocalAccounts && enable_aad
-  autoUpgradeProfile: !empty(upgradeChannel) ? {
-    upgradeChannel: upgradeChannel
-  } : {}
+  autoUpgradeProfile: {upgradeChannel: upgradeChannel}
   addonProfiles: !empty(aks_addons1) ? aks_addons1 : aks_addons
   autoScalerProfile: autoScale ? AutoscaleProfile : {}
   oidcIssuerProfile: {
@@ -1194,6 +1191,7 @@ resource fluxAddon 'Microsoft.KubernetesConfiguration/extensions@2022-04-02-prev
     }
     configurationProtectedSettings: {}
   }
+  dependsOn: [daprExtension] //Chaining dependencies because of: https://github.com/Azure/AKS-Construction/issues/385
 }
 output fluxReleaseNamespace string = fluxGitOpsAddon ? fluxAddon.properties.scope.cluster.releaseNamespace : ''
 


### PR DESCRIPTION
## PR Summary

This fixes a bug where if you configured Flux and Dapr, then they would conflict with each other whilst installing simultaneously.

It also addresses another small issue with the default parameter value for upgradeChannel

Closes #385 
Closes #389 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
