### PR TITLE
Change to load VM sku's and filter on location

### DIFF
--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -2,29 +2,20 @@
 import React from 'react';
 import { mergeStyles, TextField, Link, Separator, DropdownMenuItemType, Dropdown, Slider, Stack, Text, Label, ChoiceGroup, Checkbox, MessageBar, MessageBarType } from '@fluentui/react';
 import { adv_stackstyle, getError, hasError } from './common'
+import vmSKUs from '../vmSKUs.json'
 
 const optionRootClass = mergeStyles({
     display: 'flex',
     alignItems: 'baseline'
 });
 
-export const VMs = [
-    { key: 'b', text: 'Burstable (dev/test)', itemType: DropdownMenuItemType.Header },
-    { key: 'Standard_B2s', text: '2 vCPU,  4 GiB RAM,   8GiB SSD, 40%	-> 200% CPU', eph: false },
-    { key: 'dv2', text: 'General purpose V2', itemType: DropdownMenuItemType.Header },
-    { key: 'default', text: '2 vCPU,  7 GiB RAM,  14GiB SSD,  86 GiB cache (8000 IOPS)', eph: false },
-    { key: 'Standard_DS3_v2', text: '4 vCPU, 14 GiB RAM,  28GiB SSD, 172 GiB cache (16000 IOPS)', eph: true },
-    { key: 'dv4', text: 'General purpose V4', itemType: DropdownMenuItemType.Header },
-    { key: 'Standard_D2ds_v4', text: '2 vCPU,  8 GiB RAM,  75GiB SSD,               (19000 IOPS)', eph: false },
-    { key: 'Standard_D4ds_v4', text: '4 vCPU, 16 GiB RAM, 150GiB SSD, 100 GiB cache (38500 IOPS)', eph: false },
-    { key: 'Standard_D8ds_v4', text: '8 vCPU, 32 GiB RAM, 300GiB SSD,               (77000 IOPS)', eph: true },
-    { key: 'fv2', text: 'Compute optimized', itemType: DropdownMenuItemType.Header },
-    { key: 'Standard_F2s_v2', text: '2 vCPU,  4 GiB RAM,  16GiB SSD,               (3200 IOPS)', eph: false }
-]
+export var VMs = vmSKUs
 
 export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
     const { net, addons, cluster, deploy } = tabValues
     const defenderFeatureFlag = featureFlag.includes('defender')
+
+    VMs = vmSKUs.filter(l => {return l.location.toLowerCase().match(deploy.location.toLowerCase()) || l.location.toLowerCase().match("global")}) //Filter VM Sku list based on location
 
 
     function sliderUpdateFn(updates) {

--- a/helper/src/vmSKUs.json
+++ b/helper/src/vmSKUs.json
@@ -1,0 +1,13 @@
+[
+    { "key": "b", "text": "Burstable (dev/test)", "itemType": "DropdownMenuItemType.Header", "location": "global"},
+    { "key": "Standard_B2s", "text": "2 vCPU,  4 GiB RAM,   8GiB SSD, 40% -> 200% CPU", "eph": false, "location": "global"},
+    { "key": "dv2", "text": "General purpose V2", "itemType": "DropdownMenuItemType.Header", "location": "global"  },
+    { "key": "default", "text": "2 vCPU,  7 GiB RAM,  14GiB SSD,  86 GiB cache (8000 IOPS)", "eph": false, "location": "global"},
+    { "key": "Standard_DS3_v2", "text": "4 vCPU, 14 GiB RAM,  28GiB SSD, 172 GiB cache (16000 IOPS)", "eph": true, "location": "global"},
+    { "key": "dv4", "text": "General purpose V4", "itemType": "DropdownMenuItemType.Header", "location": "global"},
+    { "key": "Standard_D2ds_v4", "text": "2 vCPU,  8 GiB RAM,  75GiB SSD,               (19000 IOPS)", "eph": false, "location": "global"},
+    { "key": "Standard_D4ds_v4", "text": "4 vCPU, 16 GiB RAM, 150GiB SSD, 100 GiB cache (38500 IOPS)", "eph": false, "location": "global"},
+    { "key": "Standard_D8ds_v4", "text": "8 vCPU, 32 GiB RAM, 300GiB SSD,               (77000 IOPS)", "eph": true, "location": "global"},
+    { "key": "fv2", "text": "Compute optimized", "itemType": "DropdownMenuItemType.Header", "location": "global"},
+    { "key": "Standard_F2s_v2", "text": "2 vCPU,  4 GiB RAM,  16GiB SSD,               (3200 IOPS)", "eph": false, "location": "global"}
+]


### PR DESCRIPTION
## PR Summary

Changed the logic to dynamically load the VM sku's from a json file and removed the hardcoded list in the clusterTab.js. 
Added logic to filter the sku's by location and also added a  "global" change to sku's availability across all regions.
To achieve this added a new property to the json file called "location" 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
