### PR TITLE
Update default address prefix for App Gateway Ingress Controller addon

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1160,11 +1160,10 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
     enabled: true
     config: {
       applicationGatewayName: appgwName
-      subnetCIDR: '10.2.0.0/16'
+      subnetCIDR: '10.225.0.0/16'
     }
   }
 }) : aks_addons
-
 
 var aks_identity = {
   type: 'UserAssigned'
@@ -1176,7 +1175,6 @@ var aks_identity = {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
-
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {


### PR DESCRIPTION
## PR Summary

Observed change in the address prefix for default networking in an AKS cluster deployment. We have updated the default address prefix used by AKS-C to work in this scenario.

<!-- summarize your PR between here and complete the checklist with 'x' between the brackets -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
