### PR TITLE
Node pool name customisation

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1089,7 +1089,7 @@ var systemPoolPresets = {
 }
 
 var systemPoolBase = {
-  name: 'npsystem'
+  name:  JustUseSystemPool ? nodePoolName : 'npsystem'
   mode: 'System'
   osType: 'Linux'
   maxPods: 30
@@ -1127,6 +1127,10 @@ var agentPoolProfileUser = union({
 }, userPoolVmProfile)
 
 var agentPoolProfiles = JustUseSystemPool ? array(union(systemPoolBase, userPoolVmProfile)) : concat(array(union(systemPoolBase, SystemPoolType=='Custom' && SystemPoolCustomPreset != {} ? SystemPoolCustomPreset : systemPoolPresets[SystemPoolType])), array(agentPoolProfileUser))
+
+
+output userNodePoolName string = nodePoolName
+output systemNodePoolName string = JustUseSystemPool ? nodePoolName : 'npsystem'
 
 var akssku = AksPaidSkuForSLA ? 'Paid' : 'Free'
 

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -890,6 +890,11 @@ param agentCount int = 3
 param agentCountMax int = 0
 var autoScale = agentCountMax > agentCount
 
+@minLength(3)
+@maxLength(20)
+@description('Name for user node pool')
+param nodePoolName string = 'npuser01'
+
 @description('Allocate pod ips dynamically')
 param cniDynamicIpAllocation bool = false
 
@@ -1108,7 +1113,7 @@ var userPoolVmProfile = {
 }
 
 var agentPoolProfileUser = union({
-  name: 'npuser01'
+  name: nodePoolName
   mode: 'User'
   osDiskType: osDiskType
   osDiskSizeGB: osDiskSizeGB

--- a/cspell.json
+++ b/cspell.json
@@ -101,6 +101,7 @@
         "noopener",
         "noreferrer",
         "notopmargin",
+        "npuser",
         "NSG's",
         "omsagent",
         "pagename",

--- a/cspell.json
+++ b/cspell.json
@@ -97,6 +97,7 @@
         "netpolicy",
         "networkpolicy",
         "newp",
+        "nodepool",
         "noopener",
         "noreferrer",
         "notopmargin",

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -116,6 +116,7 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         label={`Node count range ${cluster.autoscale ? 'range' : ''}`} min={0}  max={100} step={1}
                         value={cluster.autoscale? cluster.maxCount : cluster.agentCount} showValue={true}
                         onChange={(val, range) => sliderUpdateFn(cluster.autoscale ? {agentCount: range[0], maxCount: range[1]} : {agentCount: val})} />
+                        <TextField label="User node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
                     </Stack.Item>
                 </Stack>
 

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -32,6 +32,10 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
             console.log (`agentCount=${newp.agentCount} MIN=${AGENT_COUNT_MIN} MAX=${AGENT_COUNT_MAX}`)
             console.log (`maxCount=${newp.maxCount} MIN=${MAXCOUNT_MIN}`)
 
+            if(newp.SystemPoolType!=='none' && !cluster.nodepoolName){
+                cluster.nodepoolName = 'npuser01'
+            }
+
             if (newp.maxCount < MAXCOUNT_MIN) {
                 updatevals = {...updatevals, maxCount: MAXCOUNT_MIN}
             }
@@ -116,7 +120,7 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         label={`Node count range ${cluster.autoscale ? 'range' : ''}`} min={0}  max={100} step={1}
                         value={cluster.autoscale? cluster.maxCount : cluster.agentCount} showValue={true}
                         onChange={(val, range) => sliderUpdateFn(cluster.autoscale ? {agentCount: range[0], maxCount: range[1]} : {agentCount: val})} />
-                        <TextField label="User node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
+                        <TextField placeholder='npuser01' label="User node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} required errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
                     </Stack.Item>
                 </Stack>
 

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -47,12 +47,10 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
             }
 
             //clear when changing computeType
-            if (newp.computeType)
-            {
-               updatevals = {...updatevals, vmSize: null}
-
-            }
-
+            //if (newp.computeType)
+            //{
+              // updatevals = {...updatevals, vmSize: null}
+            //}
 
             return updatevals
         })
@@ -120,7 +118,7 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         label={`Node count range ${cluster.autoscale ? 'range' : ''}`} min={0}  max={100} step={1}
                         value={cluster.autoscale? cluster.maxCount : cluster.agentCount} showValue={true}
                         onChange={(val, range) => sliderUpdateFn(cluster.autoscale ? {agentCount: range[0], maxCount: range[1]} : {agentCount: val})} />
-                        <TextField placeholder='npuser01' label="User node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} required errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
+                        <TextField placeholder='npuser01' label="Node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} required errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
                     </Stack.Item>
                 </Stack>
 

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -32,7 +32,9 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.AksPaidSkuForSLA !== defaults.cluster.AksPaidSkuForSLA && { AksPaidSkuForSLA: cluster.AksPaidSkuForSLA }),
     ...(cluster.SystemPoolType === 'none' ? { JustUseSystemPool: true } : cluster.SystemPoolType !== defaults.cluster.SystemPoolType && { SystemPoolType: cluster.SystemPoolType }),
     ...(cluster.vmSize !== defaults.cluster.vmSize && { agentVMSize: cluster.vmSize }),
-    ...(((cluster.nodepoolName.toLowerCase() !== defaults.cluster.nodepoolName  && cluster.SystemPoolType !== 'none') || ( cluster.SystemPoolType === 'none' && cluster.nodepoolName.toLowerCase() !== defaults.cluster.systemNodepoolName )) && { nodePoolName: cluster.nodepoolName }),
+    ...(((cluster.nodepoolName.toLowerCase() !== defaults.cluster.nodepoolName  && cluster.SystemPoolType !== 'none')
+        || ( cluster.SystemPoolType === 'none' && (cluster.nodepoolName.toLowerCase() !== defaults.cluster.systemNodepoolName && cluster.nodepoolName.toLowerCase() !== defaults.cluster.nodepoolName )))
+        && { nodePoolName: cluster.nodepoolName }),
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -32,7 +32,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.AksPaidSkuForSLA !== defaults.cluster.AksPaidSkuForSLA && { AksPaidSkuForSLA: cluster.AksPaidSkuForSLA }),
     ...(cluster.SystemPoolType === 'none' ? { JustUseSystemPool: true } : cluster.SystemPoolType !== defaults.cluster.SystemPoolType && { SystemPoolType: cluster.SystemPoolType }),
     ...(cluster.vmSize !== defaults.cluster.vmSize && { agentVMSize: cluster.vmSize }),
-    ...(cluster.nodepoolName !== defaults.cluster.nodepoolName && cluster.SystemPoolType !== 'none' && { nodePoolName: cluster.nodepoolName }),
+    ...(((cluster.nodepoolName.toLowerCase() !== defaults.cluster.nodepoolName  && cluster.SystemPoolType !== 'none') || ( cluster.SystemPoolType === 'none' && cluster.nodepoolName.toLowerCase() !== defaults.cluster.systemNodepoolName )) && { nodePoolName: cluster.nodepoolName }),
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -32,7 +32,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.AksPaidSkuForSLA !== defaults.cluster.AksPaidSkuForSLA && { AksPaidSkuForSLA: cluster.AksPaidSkuForSLA }),
     ...(cluster.SystemPoolType === 'none' ? { JustUseSystemPool: true } : cluster.SystemPoolType !== defaults.cluster.SystemPoolType && { SystemPoolType: cluster.SystemPoolType }),
     ...(cluster.vmSize !== defaults.cluster.vmSize && { agentVMSize: cluster.vmSize }),
-    ...(cluster.nodepoolName !== defaults.cluster.nodepoolName && { nodePoolName: cluster.nodepoolName }),
+    ...(cluster.nodepoolName !== defaults.cluster.nodepoolName && cluster.SystemPoolType !== 'none' && { nodePoolName: cluster.nodepoolName }),
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -32,6 +32,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.AksPaidSkuForSLA !== defaults.cluster.AksPaidSkuForSLA && { AksPaidSkuForSLA: cluster.AksPaidSkuForSLA }),
     ...(cluster.SystemPoolType === 'none' ? { JustUseSystemPool: true } : cluster.SystemPoolType !== defaults.cluster.SystemPoolType && { SystemPoolType: cluster.SystemPoolType }),
     ...(cluster.vmSize !== defaults.cluster.vmSize && { agentVMSize: cluster.vmSize }),
+    ...(cluster.nodepoolName !== defaults.cluster.nodepoolName && { nodePoolName: cluster.nodepoolName }),
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -40,6 +40,7 @@
             "upgradeChannel": "none",
             "SystemPoolType": "CostOptimised",
             "nodepoolName": "npuser01",
+            "systemNodepoolName": "npsystem",
             "agentCount": 3,
             "maxCount": 20,
             "computeType": "gp",

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -39,6 +39,7 @@
             "autoscale": true,
             "upgradeChannel": "none",
             "SystemPoolType": "CostOptimised",
+            "nodepoolName": "npuser01",
             "agentCount": 3,
             "maxCount": 20,
             "computeType": "gp",


### PR DESCRIPTION
## PR Summary

User node pool name should be customisable 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue: 
- [x] Screenshot of UI changes (if PR includes UI changes)


As described in issue https://github.com/Azure/AKS-Construction/issues/461, user node pool is made configurable

![image](https://user-images.githubusercontent.com/38279473/201997047-62797ded-5a50-4785-aa0b-4aac7ca42cd3.png)

In case of only system node pools, the parameter is not set. 

If no value provided by user, it defaults to npuser01, the original string that was used
