### PR TITLE
Nodepool name - limit to 12 characters

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -891,7 +891,7 @@ param agentCountMax int = 0
 var autoScale = agentCountMax > agentCount
 
 @minLength(3)
-@maxLength(20)
+@maxLength(12)
 @description('Name for user node pool')
 param nodePoolName string = 'npuser01'
 

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -118,7 +118,15 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         label={`Node count range ${cluster.autoscale ? 'range' : ''}`} min={0}  max={100} step={1}
                         value={cluster.autoscale? cluster.maxCount : cluster.agentCount} showValue={true}
                         onChange={(val, range) => sliderUpdateFn(cluster.autoscale ? {agentCount: range[0], maxCount: range[1]} : {agentCount: val})} />
-                        <TextField placeholder='npuser01' label="Node pool name" onChange={(ev, val) => updateFn('nodepoolName', val)} required errorMessage={getError(invalidArray, 'nodepoolName')} value={cluster.nodepoolName} />
+
+                        <TextField
+                        placeholder='npuser01'
+                        label="Node pool name"
+                        maxLength={12}
+                        onChange={(ev, val) => updateFn('nodepoolName', val)}
+                        required
+                        errorMessage={getError(invalidArray, 'nodepoolName')}
+                        value={cluster.nodepoolName} />
                     </Stack.Item>
                 </Stack>
 


### PR DESCRIPTION
## PR Summary

Need to drop the limit from 20 to 12, to stop invalid nodepoolnames being used.

> For Linux node pools, the length must be between 1 and 12 characters. For Windows node pools, the length must be between 1 and 6 characters. https://learn.microsoft.com/en-us/azure/aks/use-system-pools?tabs=azure-cli#limitations

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
