### PR TITLE
Validate helper node pool name- fixes issue 485

### DIFF
--- a/helper/src/components/portalnav.js
+++ b/helper/src/components/portalnav.js
@@ -360,6 +360,7 @@ export default function PortalNav({ config }) {
   invalidFn('deploy', 'githubrepo', deploy.deployItemKey === 'github' && (!deploy.githubrepo || !deploy.githubrepo.match('https://github.com/[^/ ]+/[^/ ]+$')), 'enter repo URL. eg: https://github.com/org/repo')
   invalidFn('deploy', 'githubrepobranch', deploy.deployItemKey === 'github' && !deploy.githubrepobranch, 'Please enter your application GitHub repo branch the can run the workflow')
   invalidFn('deploy', 'selectedTemplate', !deploy.templateVersions.find(t => t.key === deploy.selectedTemplate), `Invalid release name: ${deploy.selectedTemplate}, ensure all assests are attached`)
+  invalidFn('cluster', 'nodepoolName', !cluster.nodepoolName || cluster.nodepoolName.match(/^[a-z][a-z0-9]*$/i) === null || cluster.nodepoolName.length > 12  , 'The name of a node pool must start with a lowercase letter and can only contain alphanumeric characters. For Linux node pools the length must be between 1 and 12 characters')
 
 
   function _customRenderer(page, link, defaultRenderer) {


### PR DESCRIPTION
## PR Summary

This PR validates node pool name entry according to AKS requirements. The validation is for Linux node pools

No UI changes and only 1 line 
![image](https://user-images.githubusercontent.com/38279473/208460988-03dfe436-fdf8-484d-b689-5f6c6f680fc2.png)

Closes #485 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
