### PR TITLE
Improve hyperlink accessibility in dark mode #269

### DIFF
--- a/helper/src/index.css
+++ b/helper/src/index.css
@@ -82,3 +82,8 @@ code {
     height: 60px;
     margin-top: 20px
 }
+
+
+a {
+    color: #9370DB !important;
+}


### PR DESCRIPTION
## PR Summary

Improve accessibility of hyperlinks in both light and dark mode by adding a class that uses a pale purpose color that has a good contrast ratio with both backgrounds, resolves #269

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)


![darkmode](https://user-images.githubusercontent.com/361399/213860665-b5a5c1a9-9556-4616-83bd-3cb3bc9e7ba3.png)

![lightmode](https://user-images.githubusercontent.com/361399/213860679-a3249983-7748-400e-8536-fbb5a6a7abec.png)
