### PR TITLE
Enable uptime SLA by default

### DIFF
--- a/helper/src/configpresets/entScale.json
+++ b/helper/src/configpresets/entScale.json
@@ -57,7 +57,8 @@
                                 "agentCount": 2,
                                 "maxCount": 4,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "networkPolicy": "none",
@@ -143,7 +144,8 @@
                                 "apisecurity": "private",
                                 "autoscale": true,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",
@@ -229,7 +231,8 @@
                                 "apisecurity": "private",
                                 "autoscale": true,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",

--- a/helper/src/configpresets/principals.json
+++ b/helper/src/configpresets/principals.json
@@ -164,7 +164,8 @@
                                 "enable_aad": false,
                                 "AksDisableLocalAccounts": false,
                                 "apisecurity": "none",
-                                "DefenderForContainers": false
+                                "DefenderForContainers": false,
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "networkPolicy": "none",
@@ -237,7 +238,8 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "whitelist",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",
@@ -342,7 +344,8 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "private",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",


### PR DESCRIPTION
## PR Summary
The enterprise scale, AKS baseline and others should enable uptime SLA by default #500

### Title
Enable AKS Uptime SLA by default

### Summarized changes
Updated "AksPaidSkuForSLA": true/false on required clusters

### Example of changes
#### Before
![image](https://user-images.githubusercontent.com/93328502/214679462-5280308a-0963-474c-bd07-9e53b20124bb.png)

#### After
![image](https://user-images.githubusercontent.com/93328502/214679343-5994f227-0dca-4d4b-9593-32041fbb0b18.png)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
