### PR TITLE
Enable Uptime SLA text

### DIFF
--- a/helper/package-lock.json
+++ b/helper/package-lock.json
@@ -15,7 +15,7 @@
         "playwright-expect": "^0.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
       }
     },

--- a/helper/package.json
+++ b/helper/package.json
@@ -11,7 +11,7 @@
     "playwright-expect": "^0.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -70,7 +70,7 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                             selectedKey={cluster.AksPaidSkuForSLA}
                             options={[
                                 { key: false, text: 'Free clusters with a service level objective (SLO) of 99.5%' },
-                                { key: true, text: 'Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint' }
+                                { key: true, text: 'Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones.' }
                             ]}
                             onChange={(ev, { key }) => updateFn("AksPaidSkuForSLA", key)}
                         />

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -69,8 +69,8 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         <ChoiceGroup
                             selectedKey={cluster.AksPaidSkuForSLA}
                             options={[
-                                { key: false, text: 'Free clusters with a service level objective (SLO) of 99.5%' },
-                                { key: true, text: 'Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint for clusters that use Availability Zones' }
+                                { key: false, text: 'Free clusters with a service level objective (SLO) of 99.9%' },
+                                { key: true, text: 'Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint' }
                             ]}
                             onChange={(ev, { key }) => updateFn("AksPaidSkuForSLA", key)}
                         />

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -69,7 +69,7 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                         <ChoiceGroup
                             selectedKey={cluster.AksPaidSkuForSLA}
                             options={[
-                                { key: false, text: 'Free clusters with a service level objective (SLO) of 99.9%' },
+                                { key: false, text: 'Free clusters with a service level objective (SLO) of 99.5%' },
                                 { key: true, text: 'Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint' }
                             ]}
                             onChange={(ev, { key }) => updateFn("AksPaidSkuForSLA", key)}

--- a/helper/src/configpresets/entScale.json
+++ b/helper/src/configpresets/entScale.json
@@ -57,7 +57,8 @@
                                 "agentCount": 2,
                                 "maxCount": 4,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "networkPolicy": "none",
@@ -143,7 +144,8 @@
                                 "apisecurity": "private",
                                 "autoscale": true,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",
@@ -229,7 +231,8 @@
                                 "apisecurity": "private",
                                 "autoscale": true,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",

--- a/helper/src/configpresets/principals.json
+++ b/helper/src/configpresets/principals.json
@@ -24,7 +24,8 @@
                                 "SystemPoolType": "none",
                                 "autoscale": false,
                                 "upgradeChannel": "none",
-                                "DefenderForContainers": false
+                                "DefenderForContainers": false,
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "registry": "none",
@@ -66,7 +67,8 @@
                             "cluster": {
                                 "SystemPoolType": "CostOptimised",
                                 "autoscale": false,
-                                "upgradeChannel": "none"
+                                "upgradeChannel": "none",
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "registry": "none",
@@ -111,7 +113,8 @@
                             "cluster": {
                                 "SystemPoolType": "CostOptimised",
                                 "autoscale": true,
-                                "upgradeChannel": "stable"
+                                "upgradeChannel": "stable",
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "registry": [
@@ -164,8 +167,7 @@
                                 "enable_aad": false,
                                 "AksDisableLocalAccounts": false,
                                 "apisecurity": "none",
-                                "DefenderForContainers": false,
-                                "AksPaidSkuForSLA": false
+                                "DefenderForContainers": false
                             },
                             "addons": {
                                 "networkPolicy": "none",
@@ -238,8 +240,7 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "whitelist",
-                                "DefenderForContainers": true,
-                                "AksPaidSkuForSLA": true
+                                "DefenderForContainers": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",
@@ -344,8 +345,7 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "private",
-                                "DefenderForContainers": true,
-                                "AksPaidSkuForSLA": true
+                                "DefenderForContainers": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",

--- a/helper/src/configpresets/principals.json
+++ b/helper/src/configpresets/principals.json
@@ -164,7 +164,8 @@
                                 "enable_aad": false,
                                 "AksDisableLocalAccounts": false,
                                 "apisecurity": "none",
-                                "DefenderForContainers": false
+                                "DefenderForContainers": false,
+                                "AksPaidSkuForSLA": false
                             },
                             "addons": {
                                 "networkPolicy": "none",
@@ -237,7 +238,8 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "whitelist",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",
@@ -342,7 +344,8 @@
                                 "enable_aad": true,
                                 "AksDisableLocalAccounts": true,
                                 "apisecurity": "private",
-                                "DefenderForContainers": true
+                                "DefenderForContainers": true,
+                                "AksPaidSkuForSLA": true
                             },
                             "addons": {
                                 "networkPolicy": "azure",


### PR DESCRIPTION
## Update SLA  text, issue #500 

Related to #504 
Update
From: _"Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint"_
To: _"Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones"_

Per @mosabami request: _"hello Oscar, finally heard back from PG. it looks like the 99.95% is for clusters that have AZ. its 99.9 for those that dont. Looks like we need to change the text to: Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones_"

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
