### PR TITLE
Update SLA text

### DIFF
--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -79,7 +79,7 @@ export default function ({ defaults, tabValues, updateFn, featureFlag, invalidAr
                             selectedKey={cluster.AksPaidSkuForSLA}
                             options={[
                                 { key: false, text: 'Free clusters with a service level objective (SLO) of 99.5%' },
-                                { key: true, text: 'Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint' }
+                                { key: true, text: 'Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones.' }
                             ]}
                             onChange={(ev, { key }) => updateFn("AksPaidSkuForSLA", key)}
                         />


### PR DESCRIPTION
## PR Summary: Update SLA text per #500

Related to [#504](https://github.com/Azure/AKS-Construction/pull/504)

**Update**
**From**: _"Uptime SLA guarantees 99.95% availability of the Kubernetes API server endpoint"_
**To**: _"Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones"_

Per [@mosabami](https://github.com/mosabami) request: _"hello Oscar, finally heard back from PG. it looks like the 99.95% is for clusters that have AZ. its 99.9 for those that dont. Looks like we need to change the text to: Uptime SLA: 99.9% availability for the Kubernetes API server for clusters without Availability zones"_

![image](https://user-images.githubusercontent.com/93328502/216123219-336744af-11a7-4e56-8cec-fe24a5c160eb.png)


## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [X] Link to a filed issue
- [X] Screenshot of UI changes (if PR includes UI changes)
