### PR TITLE
Continuous Deployment for Helper

### DIFF
--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -66,6 +66,18 @@ jobs:
             exit 1
           fi
 
+      - name: Verify NO changes to Helper dependencies file
+        run: |
+          bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat helper/src/dependencies.json)
+          if [ -z "$bicepChanges" ]
+          then
+            echo No Changes In Helper dependencies file found
+          else
+            echo Helper dependencies file Changes Detected, exiting
+            echo $bicepChanges
+            exit 1
+          fi
+
       - name: Verify changes to the helper directory
         run: |
           bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat helper/)

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   VerifySoftPossible:
     runs-on: ubuntu-latest
+    name: Is Soft Release Possible
     outputs:
       LatestAkscVersionTag: ${{ steps.AkscTags.outputs.LATEST}}
     steps:
-      #- uses: actions/checkout@v3.3.0
       - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
@@ -27,7 +27,7 @@ jobs:
           LATEST=$(curl https://api.github.com/repos/Azure/AKS-Construction/releases/latest | jq '.tag_name' -r)
           echo "LATEST=$LATEST" >> $GITHUB_OUTPUT
 
-      - name: Output diff from main to the latest release
+      - name: Output git diff from main to the latest release
         run: git diff ${{ steps.AkscTags.outputs.LATEST }} --stat
 
       - name: Verify NO changes to bicep directory
@@ -38,6 +38,7 @@ jobs:
             echo No Changes In Bicep directory found
           else
             echo Bicep Changes Detected, exiting
+            echo $bicepChanges
             exit 1
           fi
 

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main, gb-softrelease]
+    branches: [main]
 
 jobs:
   VerifySoftPossible:

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -1,0 +1,152 @@
+name: Soft Release Non-Breaking Changes (CD)
+# This workflow compares the changes in main to the latest release;
+# If there are changes to the /helper directory but not /bicep then a Soft Release of the Helper is possible
+# As part of the soft release process, a full test will be run to ensure that it will work
+# Then CD of main to the production web site will be completed
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [main, gb-softrelease]
+
+jobs:
+  VerifySoftPossible:
+    runs-on: ubuntu-latest
+    outputs:
+      LatestAkscVersionTag: ${{ steps.AkscTags.outputs.LATEST}}
+    steps:
+      - name: Get latest AKSC version
+        id: AkscTags
+        run: |
+          LATEST=$(curl https://api.github.com/repos/Azure/AKS-Construction/releases/latest | jq '.tag_name' -r)
+          echo "LATEST=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Output diff from main to the latest release
+        run: git diff ${{ steps.AkscTags.outputs.LATEST }} --stat
+
+      - name: Verify NO changes to bicep directory
+        run: |
+          bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat bicep/)
+          if [ -z $bicepChanges ]
+          then
+            echo No Changes In Bicep directory found
+          else
+            echo Bicep Changes Detected, exiting
+            exit 1
+          fi
+
+      - name: Verify changes to the helper directory
+        run: |
+          bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat helper/)
+          if [ -z $bicepChanges ]
+          then
+            echo No Changes In Helper directory found, existing
+            exit 1
+          else
+            echo Helper Changes Detected - Soft release possible
+          fi
+
+  SetupWF:
+    runs-on: ubuntu-latest
+    outputs:
+      REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.templateRelease }}
+    steps:
+      - name: Reusable workflow
+        run: |
+          echo "Resuable workflows can't be directly passed ENV/INPUTS (yet)"
+          echo "So we need this job to be able to access the value in env.RG"
+          echo "see https://github.community/t/reusable-workflow-env-context-not-available-in-jobs-job-id-with/206111"
+
+  TestWebApp:
+    needs: [SetupWF, VerifySoftPossible]
+    uses: ./.github/workflows/ghpagesTest.yml
+    with:
+      REACT_APP_TEMPLATERELEASE: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}
+      doAzCmdDeployment: true
+    secrets:
+      AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+
+  BuildWebApp:
+    runs-on: ubuntu-latest
+    name: Build Web App Artifact
+    needs: VerifySoftPossible
+    env:
+      templateRelease: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Job Parameter Checking
+        run: |
+          echo "GitHub Ref: ${{ github.ref }}"
+
+      - name: Azure Login
+        uses: Azure/login@v1.4.6
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Build VM Sku json file
+        timeout-minutes: 3
+        run: |
+          cd postdeploy/scripts
+          chmod +x generate-vm-sku-list-v2.sh
+          ./generate-vm-sku-list-v2.sh
+
+      - name: Build node app with bicep release
+        run: |
+          cd helper
+          npm install
+          REACT_APP_APPINSIGHTS_KEY=${{ secrets.REACT_APP_APPINSIGHTS_KEY}} REACT_APP_TEMPLATERELEASE="${{env.templateRelease}}"  npm run build
+
+      - name: Create GitHub pages release artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: HelperApp
+          path: helper/build
+
+  DeployWebAppToCanary:
+    runs-on: ubuntu-latest
+    name: Deploy Web App to Canary-Page branch
+    if: ${{ always() }}
+    needs: [BuildWebApp , TestWebApp, VerifySoftPossible]
+    env:
+      templateRelease: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}
+    steps:
+      - uses: actions/download-artifact@v3.0.2
+        with:
+          name: HelperApp
+          path: helperapp
+
+      - name: Deploy to GitHub Pages Canary
+        uses: crazy-max/ghaction-github-pages@v3.1.0
+        with:
+          target_branch: gh-pages-canary
+          commit_message: Pages Release. Canary ${{env.templateRelease}}
+          build_dir: helperapp
+          keep_history: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  DeployWebAppToProd:
+    runs-on: ubuntu-latest
+    name: Deploy Web App to Prod Pages
+    if: ${{ always() && github.ref == 'refs/heads/main'}}
+    environment: UI-Deploy-Manual-Approval #To enable true CD, we need to remove this line.
+    needs: [BuildWebApp , DeployWebAppToCanary, VerifySoftPossible]
+    env:
+      templateRelease: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}
+    steps:
+      - uses: actions/download-artifact@v3.0.2
+        with:
+          name: HelperApp
+          path: helperapp
+
+      - name: Deploy to GitHub Pages Prod
+        uses: crazy-max/ghaction-github-pages@v3.1.0
+        with:
+          target_branch: gh-pages
+          commit_message: Pages Release. Prod ${{env.templateRelease}}
+          build_dir: helperapp
+          keep_history: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -16,7 +16,10 @@ jobs:
     outputs:
       LatestAkscVersionTag: ${{ steps.AkscTags.outputs.LATEST}}
     steps:
+      #- uses: actions/checkout@v3.3.0
       - uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
 
       - name: Get latest AKSC version
         id: AkscTags
@@ -109,7 +112,6 @@ jobs:
   DeployWebAppToCanary:
     runs-on: ubuntu-latest
     name: Deploy Web App to Canary-Page branch
-    if: ${{ always() }}
     needs: [BuildWebApp , TestWebApp, VerifySoftPossible]
     env:
       templateRelease: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main]
+    branches: [main, gb-softrelease]
 
 jobs:
   VerifySoftPossible:
@@ -53,19 +53,8 @@ jobs:
             echo $bicepChanges
           fi
 
-  SetupWF:
-    runs-on: ubuntu-latest
-    outputs:
-      REACT_APP_TEMPLATERELEASE: ${{ github.event.inputs.templateRelease }}
-    steps:
-      - name: Reusable workflow
-        run: |
-          echo "Resuable workflows can't be directly passed ENV/INPUTS (yet)"
-          echo "So we need this job to be able to access the value in env.RG"
-          echo "see https://github.community/t/reusable-workflow-env-context-not-available-in-jobs-job-id-with/206111"
-
   TestWebApp:
-    needs: [SetupWF, VerifySoftPossible]
+    needs: [VerifySoftPossible]
     uses: ./.github/workflows/ghpagesTest.yml
     with:
       REACT_APP_TEMPLATERELEASE: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify NO changes to bicep directory
         run: |
           bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat bicep/)
-          if [ -z $bicepChanges ]
+          if [ -z "$bicepChanges" ]
           then
             echo No Changes In Bicep directory found
           else
@@ -44,7 +44,7 @@ jobs:
       - name: Verify changes to the helper directory
         run: |
           bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat helper/)
-          if [ -z $bicepChanges ]
+          if [ -z "$bicepChanges" ]
           then
             echo No Changes In Helper directory found, existing
             exit 1

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
   push:
-    branches: [main]
+    branches: [main, gb-softrelease]
 
 jobs:
   VerifySoftPossible:
@@ -38,6 +38,30 @@ jobs:
             echo No Changes In Bicep directory found
           else
             echo Bicep Changes Detected, exiting
+            echo $bicepChanges
+            exit 1
+          fi
+
+      - name: Verify NO changes to postdeploy directory
+        run: |
+          bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat postdeploy/)
+          if [ -z "$bicepChanges" ]
+          then
+            echo No Changes In postdeploy directory found
+          else
+            echo postdeploy Changes Detected, exiting
+            echo $bicepChanges
+            exit 1
+          fi
+
+      - name: Verify NO changes to Helper config file
+        run: |
+          bicepChanges=$(git diff ${{ steps.AkscTags.outputs.LATEST }} --stat helper/src/config.json)
+          if [ -z "$bicepChanges" ]
+          then
+            echo No Changes In Helper config file found
+          else
+            echo Helper config file Changes Detected, exiting
             echo $bicepChanges
             exit 1
           fi

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -16,6 +16,8 @@ jobs:
     outputs:
       LatestAkscVersionTag: ${{ steps.AkscTags.outputs.LATEST}}
     steps:
+      - uses: actions/checkout@v3.3.0
+
       - name: Get latest AKSC version
         id: AkscTags
         run: |

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy Web App to Prod Pages
     if: ${{ always() && github.ref == 'refs/heads/main'}}
-    environment: UI-Deploy-Manual-Approval #To enable true CD, we need to remove this line.
+    environment: UI-Deploy-Soft-Release
     needs: [BuildWebApp , DeployWebAppToCanary, VerifySoftPossible]
     env:
       templateRelease: ${{ needs.VerifySoftPossible.outputs.LatestAkscVersionTag }}

--- a/.github/workflows/release-soft.yml
+++ b/.github/workflows/release-soft.yml
@@ -50,6 +50,7 @@ jobs:
             exit 1
           else
             echo Helper Changes Detected - Soft release possible
+            echo $bicepChanges
           fi
 
   SetupWF:


### PR DESCRIPTION
## PR Summary

Where there has been a successful PR to main with the following attributes;
- Changes in /helper
- NO Changes in /bicep

Then a soft release (releasing the Helper web app, but not a new GitHub release tag) is possible.

This PR introduces a new workflow to release JUST THE HELPER.
It compares whats in main to the release tag, and if the above conditions are met - initiates a release of the Helper.

Note we still do;
1. Playwright web tests
2. Extraction of the default AZ command and an `az deployment validate` on the template/params

> Note that we do not run a full infrastructure deployment test, but we can easily do this to happen every time or by some other criteria.

![image](https://user-images.githubusercontent.com/17914476/217213053-852e09d9-9456-49f2-83be-4ba18aac4061.png)

![image](https://user-images.githubusercontent.com/17914476/217214447-7fce3ad9-6cdf-4de7-a07d-72485e11971d.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
