### PR TITLE
Added new sku family (DSv3) to the HELPER

### DIFF
--- a/helper/src/skuFamilies.json
+++ b/helper/src/skuFamilies.json
@@ -1,5 +1,6 @@
 [
     {"key": "standardDSv2Family", "text": "General Purpose V2", "computeType": "gp"},
+    {"key": "standardDSv3Family", "text": "General Purpose V3", "computeType": "gp"},
     {"key": "standardDDSv4Family", "text": "General Purpose V4", "computeType": "gp"},
     {"key": "standardFSv2Family", "text": "Compute Optimized","computeType": "gp"},
     {"key": "standardBSFamily", "text": "Burstable (dev/test)","computeType": "gp"}


### PR DESCRIPTION
## PR Summary

Needed to add a new sku family to the list of available sku's (Standard DS v3):

This is driven by the skuFamilies.json file in the helper/src folder. Where the following line was added: 
    {"key": "standardDSv3Family", "text": "General Purpose V3", "computeType": "gp"},

To generate the new list a full release is required which would generate the vmSKUs.json file which the helper loads for clusters.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
