### PR TITLE
Acknowledge Cilium Network Policy

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -935,6 +935,7 @@ param ebpfDataplane string = ''
   ''
   'azure'
   'calico'
+  'cilium'
 ])
 @description('The network policy to use.')
 param networkPolicy string = ''

--- a/helper/src/components/addonsTab.js
+++ b/helper/src/components/addonsTab.js
@@ -354,9 +354,9 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray }) {
                     selectedKey={addons.networkPolicy}
                     options={[
                         { "data-testid":'addons-netpolicy-none', key: 'none', text: 'No restrictions, all PODs can access each other' },
-                        { "data-testid":'addons-netpolicy-calico', key: 'calico', text: 'Use Network Policy addon with Calico to implemented intra-cluster traffic restrictions (driven from "NetworkPolicy" objects)' },
-                        { "data-testid":'addons-netpolicy-azure', key: 'azure', text: 'Use Network Policy addon with Azure provider to implemented intra-cluster traffic restrictions (driven from "NetworkPolicy" objects)' }
-
+                        { "data-testid":'addons-netpolicy-calico', disabled: net.ebpfDataplane, key: 'calico', text: 'Use Network Policy addon with Calico to implemented intra-cluster traffic restrictions (driven from "NetworkPolicy" objects)' },
+                        { "data-testid":'addons-netpolicy-azure', disabled: net.ebpfDataplane, key: 'azure', text: 'Use Network Policy addon with Azure provider to implemented intra-cluster traffic restrictions (driven from "NetworkPolicy" objects)' },
+                        { "data-testid":'addons-netpolicy-cilium', disabled: true, key: 'cilium', text: 'The Cilium ebpf backplane will leverage the Cilium Network Policy, it cannot be selected independently or explicitly.' }
                     ]}
                     onChange={(ev, { key }) => updateFn("networkPolicy", key)}
                 />

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -78,7 +78,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
         ...( addons.logDataCap !== defaults.addons.logDataCap && {logDataCap: addons.logDataCap }),
         ...( addons.createAksMetricAlerts !== defaults.addons.createAksMetricAlerts && {createAksMetricAlerts: addons.createAksMetricAlerts })
        }),
-    ...(addons.networkPolicy !== "none" && { networkPolicy: addons.networkPolicy }),
+    ...(addons.networkPolicy !== "none" && !net.ebpfDataplane && { networkPolicy: addons.networkPolicy }),
     ...(defaults.addons.openServiceMeshAddon !== addons.openServiceMeshAddon && {openServiceMeshAddon: addons.openServiceMeshAddon }),
     ...(addons.azurepolicy !== "none" && { azurepolicy: addons.azurepolicy }),
     ...(addons.azurepolicy !== "none" && addons.azurePolicyInitiative !== defaults.addons.azurePolicyInitiative && { azurePolicyInitiative: addons.azurePolicyInitiative }),


### PR DESCRIPTION
## PR Summary

Closes #535 

Adds Cilium to the list of network policy providers
Adds logic to prevent Azure or Calico being used if the Cilium dataplane is enabled

![image](https://user-images.githubusercontent.com/17914476/224689770-8b139ef9-bec6-4804-abb2-309143c2d7eb.png)


## PR Checklist

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
