### PR TITLE
CI: Bicep install on runners - azcli workaround

### DIFF
--- a/.github/workflows/bicepBuild.yml
+++ b/.github/workflows/bicepBuild.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install Bicep
         shell: pwsh
         run: |
+          az config set bicep.use_binary_from_path=False
           az bicep install
 
       - name: Bicep build


### PR DESCRIPTION
## PR Summary

We have an issue in CI where the Azure CLI v2.46.0 on the runners does not successfully install bicep. REF: https://github.com/Azure/azure-cli/issues/25710

The [suggested workaround](https://github.com/Azure/azure-cli/issues/25710#issuecomment-1464673546) is the contents of this PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
