### PR TITLE
CI: Bicep install on runners - azcli workaround

### DIFF
--- a/.github/workflows/ghpagesTest.yml
+++ b/.github/workflows/ghpagesTest.yml
@@ -121,6 +121,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.fork }}
         shell: pwsh
         run: |
+          az config set bicep.use_binary_from_path=False
           az bicep install
 
       - name: Bicep build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Install Bicep
         shell: pwsh
-        run: az bicep install
+        run: |
+          az config set bicep.use_binary_from_path=False
+          az bicep install
 
       - name: Bicep build
         shell: pwsh
@@ -177,7 +179,9 @@ jobs:
           echo "ARTIFACTNAME=$ARTIFACTNAME" >> $Env:GITHUB_OUTPUT
 
       - name: Install Bicep
-        run: az bicep install
+        run: |
+          az config set bicep.use_binary_from_path=False
+          az bicep install
 
       - name: Bicep build
         run: |


### PR DESCRIPTION
## PR Summary

We have an issue in CI where the Azure CLI v2.46.0 on the runners does not successfully install bicep. REF: https://github.com/Azure/azure-cli/issues/25710

The [suggested workaround](https://github.com/Azure/azure-cli/issues/25710#issuecomment-1464673546) is the contents of this PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
