### PR TITLE
Terraform bumps and bugfix

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -196,7 +196,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
   }
 
   const params2tf = p => Object.keys(p).map(k => {
-    return `    ${k} = ${k.toLowerCase().endsWith('principalid') ? '{value=data.azurerm_client_config.current.client_id}' : `{value=var.${k}}`}\n`
+    return `    ${k} = ${k.toLowerCase().endsWith('principalid') ? '{value=data.azurerm_client_config.current.object_id}' : `{value=var.${k}}`}\n`
   }).join('')
 
   const params2TfVar = p => Object.keys(p).filter(p => p !== 'adminPrincipalId' &&
@@ -283,11 +283,11 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
   const deployTfProviders =
     `#providers.tf\n\n` +
     `terraform {\n` +
-    `  required_version = ">=1.1.9"\n` +
+    `  required_version = ">=1.3.2"\n` +
     `  required_providers {\n` +
     `    azurerm = {\n` +
     `      source = "hashicorp/azurerm"\n` +
-    `      version = "~>3.6"\n` +
+    `      version = "~>3.48"\n` +
     `    }\n` +
     `  }\n` +
     `}\n\n` +
@@ -312,14 +312,17 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     `  name = "AKS-C"\n` +
     `  resource_group_name = azurerm_resource_group.rg.name\n` +
     `  deployment_mode = "Incremental"\n` +
-    `  template_content = data.http.aksc_release.body\n` +
+    `  template_content = data.http.aksc_release.response_body\n` +
     `  parameters_content = jsonencode({\n` +
     params2tf(finalParams) +
     `  })\n` +
     `}`
 
   const deployTfVar = `#variables.tf\n\nvariable resourceGroupName {\n  type=string\n  default="${deploy.rg}"\n}\nvariable location {\n  type=string\n  default="${deploy.location}"\n}` + params2TfVar(finalParams)
-  const deployTfOutput = `#outputs.tf\n\noutput aksClusterName {\n  value = jsondecode(azurerm_resource_group_template_deployment.aksc_deploy.output_content).aksClusterName.value\n  description = "The name of the AKS cluster."\n}`
+  const deployTfOutput = `#outputs.tf\n\n` +
+    `output aksClusterName {\n  value = jsondecode(azurerm_resource_group_template_deployment.aksc_deploy.output_content).aksClusterName.value\n  description = "The name of the AKS cluster."\n}\n` +
+    `output userClientId {\n  value = data.azurerm_client_config.current.client_id\n  description = "Current User ClientId"\n}\n` +
+    `output userObjectId {\n  value = data.azurerm_client_config.current.object_id\n  description = "Current User ObjectId"\n}`
 
   const param_file = JSON.stringify(params2file(finalParams), null, 2).replaceAll('\\\\\\', '').replaceAll('\\\\\\', '')
 

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -287,7 +287,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     `  required_providers {\n` +
     `    azurerm = {\n` +
     `      source = "hashicorp/azurerm"\n` +
-    `      version = "~>3.6"\n` +
+    `      version = "~>3.48"\n` +
     `    }\n` +
     `  }\n` +
     `}\n\n` +

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -287,7 +287,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     `  required_providers {\n` +
     `    azurerm = {\n` +
     `      source = "hashicorp/azurerm"\n` +
-    `      version = "~>3.48"\n` +
+    `      version = "~>3.6"\n` +
     `    }\n` +
     `  }\n` +
     `}\n\n` +


### PR DESCRIPTION
## PR Summary

1. Bumps required version of tf and providers
2. Expanded outputs to aid debugging
3. http provider deprecated warning - Closes #556
4. http provider swap from client_id to object_id (emerged bug, likely provider)

Tested with big env config.
works great

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
