### PR TITLE
Cleanup Old Role Assignments in CI resource group

### DIFF
--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -127,12 +127,12 @@ jobs:
   CostEstimate:
     needs: [ReusableWF]
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
-    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.2-beta2
+    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.1
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       environment: ${{needs.ReusableWF.outputs.Environment}}
-      aceVersion: 1.2-beta2
+      aceVersion: 1.1
       templateFileURL: https://github.com/Azure/AKS-Construction/releases/download/${{ needs.ReusableWF.outputs.LatestAkscVersionTag }}/main.json
       #templateParamFileURL: ${{ needs.ReusableWF.outputs.ParamFilePath }}
       templateParamFileURL: https://raw.githubusercontent.com/Azure/AKS-Construction/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}/${{ needs.ReusableWF.outputs.ParamFilePath }}

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -18,7 +18,7 @@ on:
         required: false
       region:
         description: 'Resource Deployment Region'
-        default: 'UKWest'
+        default: 'EastUs'
         options:
           - "WestEurope"
           - "NorthEurope"

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -137,7 +137,7 @@ jobs:
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       environment: ${{needs.ReusableWF.outputs.Environment}}
-      aceVersion: 1.2-beta2
+      aceVersion: 1.1-beta2
       templateFileURL: https://github.com/Azure/AKS-Construction/releases/download/${{ needs.ReusableWF.outputs.LatestAkscVersionTag }}/main.json
       #templateParamFileURL: ${{ needs.ReusableWF.outputs.ParamFilePath }}
       templateParamFileURL: https://raw.githubusercontent.com/Azure/AKS-Construction/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}/${{ needs.ReusableWF.outputs.ParamFilePath }}

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -127,7 +127,7 @@ jobs:
   CostEstimate:
     needs: [ReusableWF]
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
-    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@main
+    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@ 1.1-beta2
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -127,7 +127,7 @@ jobs:
   CostEstimate:
     needs: [ReusableWF]
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
-    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@ 1.1-beta2
+    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.1-beta2
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -127,12 +127,12 @@ jobs:
   CostEstimate:
     needs: [ReusableWF]
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
-    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.1
-    #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
+    #uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.1
+    uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowtest
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       environment: ${{needs.ReusableWF.outputs.Environment}}
-      aceVersion: 1.1
+      aceVersion: 1.2-beta2
       templateFileURL: https://github.com/Azure/AKS-Construction/releases/download/${{ needs.ReusableWF.outputs.LatestAkscVersionTag }}/main.json
       #templateParamFileURL: ${{ needs.ReusableWF.outputs.ParamFilePath }}
       templateParamFileURL: https://raw.githubusercontent.com/Azure/AKS-Construction/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}/${{ needs.ReusableWF.outputs.ParamFilePath }}

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -127,12 +127,12 @@ jobs:
   CostEstimate:
     needs: [ReusableWF]
     if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
-    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.1-beta2
+    uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@1.2-beta2
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:
       rg: ${{ needs.ReusableWF.outputs.RG }} #Automation-Actions-AksDeployCI #'${{ env.RG }}' There seems to be an issue passing Env variables in reusable workflows
       environment: ${{needs.ReusableWF.outputs.Environment}}
-      aceVersion: 1.1-beta2
+      aceVersion: 1.2-beta2
       templateFileURL: https://github.com/Azure/AKS-Construction/releases/download/${{ needs.ReusableWF.outputs.LatestAkscVersionTag }}/main.json
       #templateParamFileURL: ${{ needs.ReusableWF.outputs.ParamFilePath }}
       templateParamFileURL: https://raw.githubusercontent.com/Azure/AKS-Construction/${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}/${{ needs.ReusableWF.outputs.ParamFilePath }}

--- a/.github/workflows/cleanupRg.yml
+++ b/.github/workflows/cleanupRg.yml
@@ -54,10 +54,15 @@ jobs:
         try {
           #Remove all but public ip addresses
           Get-AzResource -ResourceGroupName $rgToPurge.ResourceGroupName | ? {$_.ResourceType -ne "Microsoft.Network/publicIPAddresses"} | Remove-AzResource -Force
+          
           #Remove public ip addresses
           Get-AzResource -ResourceGroupName $rgToPurge.ResourceGroupName | ? {$_.ResourceType -eq "Microsoft.Network/publicIPAddresses"} | Remove-AzResource -Force
+          
           #Final run to clean other dependant resources in parent-child graph
           Get-AzResource -ResourceGroupName $rgToPurge.ResourceGroupName | Remove-AzResource -Force
+          
+          #Remove unknown/invalid role assignments from rg
+          Get-AzRoleAssignment -Scope $rgToPurge.ResourceId | where ObjectType -eq 'Unknown' | Remove-AzRoleAssignment
         }
         Catch #we're wanting to suppress failures in this step. If it fails to clean, the nightly automation will catch it.
         {


### PR DESCRIPTION
## PR Summary

Closes #555

Adds a step to the cleanup script that deletes orphaned role assignments from the Resource Group

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
