### PR TITLE
Updated outputs for Private FQDN & Private DNS Zone

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,6 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
+output privateFQDN string = !empty(aks.properties.privateFQDN) ? aks.properties.privateFQDN : ''
+// Dropping cluster name at start of privateFQDN to get private dns zone name.
+output aksPrivateDnsZoneName string =  !empty(aks.properties.privateFQDN) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,9 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
-output privateFQDN string = !empty(aks.properties.privateFQDN) ? aks.properties.privateFQDN : ''
+output privateFQDN string = !empty(privateClusterDnsMethod) ? aks.properties.privateFQDN : ''
 // Dropping cluster name at start of privateFQDN to get private dns zone name.
-output aksPrivateDnsZoneName string =  !empty(aks.properties.privateFQDN) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
+output aksPrivateDnsZoneName string =  !empty(privateClusterDnsMethod) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,9 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
-output privateFQDN string = !empty(privateClusterDnsMethod) ? aks.properties.privateFQDN : ''
+output privateFQDN string = enablePrivateCluster && privateClusterDnsMethod != 'none' ? aks.properties.privateFQDN : ''
 // Dropping cluster name at start of privateFQDN to get private dns zone name.
-output aksPrivateDnsZoneName string =  !empty(privateClusterDnsMethod) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
+output aksPrivateDnsZoneName string =  enablePrivateCluster && privateClusterDnsMethod != 'none' ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {


### PR DESCRIPTION
## PR Summary

Added bicep outputs for Private FQDN & Private DNS Zone.
This will allow the private dns zone to be more easily linked to other virtual networks.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
