### PR TITLE
Make CI cost estimates optional

### DIFF
--- a/.github/workflows/ByoVnetCI.yml
+++ b/.github/workflows/ByoVnetCI.yml
@@ -50,6 +50,11 @@ on:
         default: false
         type: boolean
         required: false
+      doCostEstimate:
+        description: 'Perform a template Cost Estimate'
+        default: false
+        type: boolean
+        required: false
       doDebugSteps:
         description: 'Run informational steps'
         default: true
@@ -116,7 +121,7 @@ jobs:
 
   CostEstimate:
     needs: [ReusableWF, Validation]
-    if: github.event_name != 'pull_request' ||  contains( github.event.pull_request.labels.*.name, 'test-deploy-byoconfig')
+    if: github.event.inputs.doCostEstimate == 'true'
     uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@main
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:

--- a/.github/workflows/ByoVnetPrivateCI.yml
+++ b/.github/workflows/ByoVnetPrivateCI.yml
@@ -36,6 +36,11 @@ on:
         default: false
         type: boolean
         required: false
+      doCostEstimate:
+        description: 'Perform a template Cost Estimate'
+        default: false
+        type: boolean
+        required: false
       doDebugSteps:
         description: 'Run informational steps'
         default: true
@@ -126,7 +131,7 @@ jobs:
 
   CostEstimate:
     needs: [ReusableWF]
-    if: github.event_name != 'pull_request' || contains( github.event.pull_request.labels.*.name, 'test-deploy-privateconfig')
+    if: github.event.inputs.doCostEstimate == 'true'
     uses: TheCloudTheory/arm-estimator/.github/workflows/estimateFromUrl.yml@main
     #uses: Gordonby/arm-estimator/.github/workflows/estimateFromUrl.yml@gb-workflowpolish
     with:


### PR DESCRIPTION
## PR Summary

Looks like we have a CI dependency problem in the cost estimate repo.
I'm going to shift the triggering of this to manual + optIn until resolved.

![image](https://user-images.githubusercontent.com/17914476/228473053-a5c7ecf0-43c7-4284-b08f-1bcce6e2c7d6.png)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
