### PR TITLE
Azure Firewall Parameter Error - Fixed

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,6 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
+output privateFQDN string = !empty(aks.properties.privateFQDN) ? aks.properties.privateFQDN : ''
+// Dropping cluster name at start of privateFQDN to get private dns zone name.
+output aksPrivateDnsZoneName string =  !empty(aks.properties.privateFQDN) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -844,7 +844,7 @@ output ApplicationGatewayName string = deployAppGw ? appgw.name : ''
 param dnsPrefix string = '${resourceName}-dns'
 
 @description('Kubernetes Version')
-param kubernetesVersion string = '1.24.9'
+param kubernetesVersion string = '1.24.10'
 
 @description('Enable Azure AD integration on AKS')
 param enable_aad bool = false

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -135,7 +135,7 @@ module network './network.bicep' = if (custom_vnet) {
     ingressApplicationGateway: ingressApplicationGateway
     vnetAppGatewaySubnetAddressPrefix: vnetAppGatewaySubnetAddressPrefix
     azureFirewalls: azureFirewalls
-    azureFirewallsSku: azureFirewallSku
+    azureFirewallSku: azureFirewallSku
     vnetFirewallSubnetAddressPrefix: vnetFirewallSubnetAddressPrefix
     vnetFirewallManagementSubnetAddressPrefix: vnetFirewallManagementSubnetAddressPrefix
     privateLinks: privateLinks

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,9 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
-output privateFQDN string = !empty(aks.properties.privateFQDN) ? aks.properties.privateFQDN : ''
+output privateFQDN string = !empty(privateClusterDnsMethod) ? aks.properties.privateFQDN : ''
 // Dropping cluster name at start of privateFQDN to get private dns zone name.
-output aksPrivateDnsZoneName string =  !empty(aks.properties.privateFQDN) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
+output aksPrivateDnsZoneName string =  !empty(privateClusterDnsMethod) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1357,6 +1357,7 @@ module userNodePool '../bicep/aksagentpool.bicep' = if (!JustUseSystemPool){
     osSKU: osSKU
     enableNodePublicIP: enableNodePublicIP
     osDiskSizeGB: osDiskSizeGB
+    availabilityZones: availabilityZones
   }
 }
 

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1207,9 +1207,9 @@ var aks_addons1 = ingressApplicationGateway ? union(aks_addons, deployAppGw ? {
 @description('Sets the private dns zone id if provided')
 var aksPrivateDnsZone = privateClusterDnsMethod=='privateDnsZone' ? (!empty(dnsApiPrivateZoneId) ? dnsApiPrivateZoneId : 'system') : privateClusterDnsMethod
 output aksPrivateDnsZone string = aksPrivateDnsZone
-output privateFQDN string = !empty(privateClusterDnsMethod) ? aks.properties.privateFQDN : ''
+output privateFQDN string = enablePrivateCluster && privateClusterDnsMethod != 'none' ? aks.properties.privateFQDN : ''
 // Dropping cluster name at start of privateFQDN to get private dns zone name.
-output aksPrivateDnsZoneName string =  !empty(privateClusterDnsMethod) ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
+output aksPrivateDnsZoneName string =  enablePrivateCluster && privateClusterDnsMethod != 'none' ? join(skip(split(aks.properties.privateFQDN, '.'),1),'.') : ''
 
 @description('Needing to seperately declare and union this because of https://github.com/Azure/AKS-Construction/issues/344')
 var managedNATGatewayProfile =  {

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -844,7 +844,7 @@ output ApplicationGatewayName string = deployAppGw ? appgw.name : ''
 param dnsPrefix string = '${resourceName}-dns'
 
 @description('Kubernetes Version')
-param kubernetesVersion string = '1.24.10'
+param kubernetesVersion string = '1.25.6'
 
 @description('Enable Azure AD integration on AKS')
 param enable_aad bool = false

--- a/bicep/network.bicep
+++ b/bicep/network.bicep
@@ -14,8 +14,8 @@ param networkSecurityGroups bool = true
 
 //Firewall
 param azureFirewalls bool = false
-param azureFirewallsSku string = 'Basic'
-param azureFirewallsManagementSeperation bool = azureFirewalls && azureFirewallsSku=='Basic'
+param azureFirewallSku string = 'Basic'
+param azureFirewallsManagementSeperation bool = azureFirewalls && azureFirewallSku=='Basic'
 param vnetFirewallSubnetAddressPrefix string = ''
 param vnetFirewallManagementSubnetAddressPrefix string = ''
 

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -65,8 +65,8 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
         ]})
     }),
     ...(net.afw && { azureFirewalls: true, ...(addons.certMan && {certManagerFW: true}), ...(net.vnet_opt === "custom" && defaults.net.vnetFirewallSubnetAddressPrefix !== net.vnetFirewallSubnetAddressPrefix && { vnetFirewallSubnetAddressPrefix: net.vnetFirewallSubnetAddressPrefix }) }),
-    ...(net.afw && net.azureFirewallsSku !== defaults.net.azureFirewallsSku && { azureFirewallsSku: net.azureFirewallsSku}),
-    ...(net.afw && net.vnetFirewallManagementSubnetAddressPrefix !== defaults.net.vnetFirewallManagementSubnetAddressPrefix && net.azureFirewallsSku==="Basic" && { vnetFirewallManagementSubnetAddressPrefix: net.vnetFirewallManagementSubnetAddressPrefix}),
+    ...(net.afw && net.azureFirewallSku !== defaults.net.azureFirewallSku && { azureFirewallSku: net.azureFirewallSku}),
+    ...(net.afw && net.vnetFirewallManagementSubnetAddressPrefix !== defaults.net.vnetFirewallManagementSubnetAddressPrefix && net.azureFirewallSku==="Basic" && { vnetFirewallManagementSubnetAddressPrefix: net.vnetFirewallManagementSubnetAddressPrefix}),
     ...(net.vnet_opt === "custom" && net.vnetprivateend && {
         privateLinks: true,
         ...(addons.csisecret === 'akvNew' && deploy.keyVaultIPAllowlist  && apiips_array.length > 0 && {keyVaultIPAllowlist: apiips_array }),

--- a/helper/src/components/networkTab.js
+++ b/helper/src/components/networkTab.js
@@ -221,14 +221,14 @@ export default function NetworkTab ({ defaults, tabValues, updateFn, invalidArra
                     onChange={(ev, v) => updateFn("afw", v)}
                     label="Implement Azure Firewall & UDR next hop" />
 
-                {net.azurefirewallsku==='Basic' &&
+                {net.azureFirewallSku==='Basic' &&
                     <MessageBar styles={{ root: { marginLeft: '50px', width:'500px', marginTop: '10px !important'}}} messageBarType={MessageBarType.warning}>Basic SKU is currently a preview service <Link href="https://learn.microsoft.com/en-gb/azure/firewall/deploy-firewall-basic-portal-policy#prerequisites">(*preview)</Link></MessageBar>
                 }
                 <Dropdown
                     styles={{ root: { marginLeft: '50px', width: '200px', marginTop: '10 !important' } }}
                     disabled={!net.afw}
                     label="Firewall SKU"
-                    onChange={(ev, { key }) => updateFn("azurefirewallsku", key)} selectedKey={net.azurefirewallsku}
+                    onChange={(ev, { key }) => updateFn("azureFirewallSku", key)} selectedKey={net.azureFirewallSku}
                     options={[
                         { key: 'Basic', text: 'Basic' },
                         { key: 'Standard', text: 'Standard' },
@@ -450,7 +450,7 @@ function CustomVNET({ net, addons, updateFn, invalidArray }) {
                     </Stack.Item>
 
                     <Stack.Item style={{ marginLeft: "20px"}}>
-                        <TextField prefix="Cidr" disabled={!net.afw || net.azurefirewallsku!=='Basic'} label="Azure Firewall management subnet" onChange={(ev, val) => updateFn("vnetFirewallManagementSubnetAddressPrefix", val)} value={net.afw ? (net.azurefirewallsku==='Basic' ? net.vnetFirewallManagementSubnetAddressPrefix : 'Management subnet for Basic SKU') : "No Firewall requested"} />
+                        <TextField prefix="Cidr" disabled={!net.afw || net.azureFirewallSku!=='Basic'} label="Azure Firewall management subnet" onChange={(ev, val) => updateFn("vnetFirewallManagementSubnetAddressPrefix", val)} value={net.afw ? (net.azureFirewallSku==='Basic' ? net.vnetFirewallManagementSubnetAddressPrefix : 'Management subnet for Basic SKU') : "No Firewall requested"} />
                     </Stack.Item>
 
                     <Stack.Item style={{ marginLeft: "20px"}}>

--- a/helper/src/components/networkTab.js
+++ b/helper/src/components/networkTab.js
@@ -221,14 +221,14 @@ export default function NetworkTab ({ defaults, tabValues, updateFn, invalidArra
                     onChange={(ev, v) => updateFn("afw", v)}
                     label="Implement Azure Firewall & UDR next hop" />
 
-                {net.azureFirewallsSku==='Basic' &&
+                {net.azurefirewallsku==='Basic' &&
                     <MessageBar styles={{ root: { marginLeft: '50px', width:'500px', marginTop: '10px !important'}}} messageBarType={MessageBarType.warning}>Basic SKU is currently a preview service <Link href="https://learn.microsoft.com/en-gb/azure/firewall/deploy-firewall-basic-portal-policy#prerequisites">(*preview)</Link></MessageBar>
                 }
                 <Dropdown
                     styles={{ root: { marginLeft: '50px', width: '200px', marginTop: '10 !important' } }}
                     disabled={!net.afw}
                     label="Firewall SKU"
-                    onChange={(ev, { key }) => updateFn("azureFirewallsSku", key)} selectedKey={net.azureFirewallsSku}
+                    onChange={(ev, { key }) => updateFn("azurefirewallsku", key)} selectedKey={net.azurefirewallsku}
                     options={[
                         { key: 'Basic', text: 'Basic' },
                         { key: 'Standard', text: 'Standard' },
@@ -450,7 +450,7 @@ function CustomVNET({ net, addons, updateFn, invalidArray }) {
                     </Stack.Item>
 
                     <Stack.Item style={{ marginLeft: "20px"}}>
-                        <TextField prefix="Cidr" disabled={!net.afw || net.azureFirewallsSku!=='Basic'} label="Azure Firewall management subnet" onChange={(ev, val) => updateFn("vnetFirewallManagementSubnetAddressPrefix", val)} value={net.afw ? (net.azureFirewallsSku==='Basic' ? net.vnetFirewallManagementSubnetAddressPrefix : 'Management subnet for Basic SKU') : "No Firewall requested"} />
+                        <TextField prefix="Cidr" disabled={!net.afw || net.azurefirewallsku!=='Basic'} label="Azure Firewall management subnet" onChange={(ev, val) => updateFn("vnetFirewallManagementSubnetAddressPrefix", val)} value={net.afw ? (net.azurefirewallsku==='Basic' ? net.vnetFirewallManagementSubnetAddressPrefix : 'Management subnet for Basic SKU') : "No Firewall requested"} />
                     </Stack.Item>
 
                     <Stack.Item style={{ marginLeft: "20px"}}>

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -113,7 +113,7 @@
         },
         "net": {
             "vnetFirewallManagementSubnetAddressPrefix": "10.240.51.0/26",
-            "azureFirewallsSku": "Standard",
+            "azureFirewallSku": "Standard",
             "maxPods": 30,
             "cniDynamicIpAllocation": false,
             "networkPluginMode": false,


### PR DESCRIPTION
## PR Summary

The networking module had a typo on the property AzureFirewallSku. It included an extra S (AzureFirewallsSku) which would cause an error as seen below.

![image](https://user-images.githubusercontent.com/48108258/234861137-505e1b4c-2165-4034-9284-3f3582f76560.png)
 
Typo corrected across main and networking bicep files. 


## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
