### PR TITLE
podSubnetID - fixing breaking change

### DIFF
--- a/bicep/aksagentpool.bicep
+++ b/bicep/aksagentpool.bicep
@@ -34,7 +34,7 @@ param nodeLabels object = {}
 param subnetId string
 
 @description('The subnet the pods will use')
-param podSubnetID string
+param podSubnetID string = ''
 
 @description('OS Type for the node pool')
 @allowed(['Linux','Windows'])


### PR DESCRIPTION
## PR Summary

A new parameter was added in #570  which did not have a default vaue.
This represents a breaking change, which we want to avoid... so i'm setting the default.

## PR Checklist

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
