### PR TITLE
Fixed font for PowerShell tab to work with light and dark browser themes.

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -510,7 +510,7 @@ az role assignment create --role "Managed Identity Operator" --assignee-principa
           }
         </PivotItem>
 
-        <PivotItem headerText="PowerShell" itemKey="deployPSArmCli" itemIcon="PasteAsCode" headerButtonProps={{disabled: deployRelease.postPS_url === undefined && deploy.selectedTemplate !== "local" ? true : false , 'style': {color: deployRelease.postPS_url === undefined && deploy.selectedTemplate !== "local" ? "grey" : "white"}}} >
+        <PivotItem headerText="PowerShell" itemKey="deployPSArmCli" itemIcon="PasteAsCode" headerButtonProps={{disabled: deployRelease.postPS_url === undefined && deploy.selectedTemplate !== "local" ? true : false , 'style': {color: deployRelease.postPS_url === undefined && deploy.selectedTemplate !== "local" ? "grey" : "none"}}} >
 
         <Stack horizontal horizontalAlign="space-between" styles={{root: { width: '100%', marginTop: '10px'}}}>
           <Stack.Item>


### PR DESCRIPTION
## PR Summary

Fixed font for PowerShell tab to work with light and dark browser themes. It was hard coding to white and worked with the dark theme. When moving to the light them it disappeared.

Changes the style to default to none to align with the other tabs. 

Please note it will be grey when disabled if hte release is missing the deploydeploy.ps1 script.

![image](https://github.com/Azure/AKS-Construction/assets/34512169/574ca2b9-8616-4351-8e1d-e4964b24110d)

## PR Checklist

- [x ] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
