### PR TITLE
Spot Instances for user pools

### DIFF
--- a/bicep/aksagentpool.bicep
+++ b/bicep/aksagentpool.bicep
@@ -46,6 +46,7 @@ param osSKU string
 @description('Assign a public IP per node')
 param enableNodePublicIP bool = false
 
+@description('If the node pool should use VM spot instances')
 param spotInstance bool = false
 
 @description('Apply a default sku taint to Windows node pools')
@@ -82,8 +83,8 @@ resource userNodepool 'Microsoft.ContainerService/managedClusters/agentPools@202
       type: 'VirtualMachineScaleSets'
       vnetSubnetID: !empty(subnetId) ? subnetId : null
       podSubnetID: !empty(podSubnetID) ? podSubnetID : null
-      upgradeSettings: {
-        maxSurge: '33%'
+      upgradeSettings: spotInstance ? {} : {
+        maxSurge:  '33%' //Spot pools can't set max surge
       }
       nodeTaints: taints
       nodeLabels: nodeLabels

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -921,6 +921,9 @@ var autoScale = agentCountMax > agentCount
 @description('Name for user node pool')
 param nodePoolName string = 'npuser01'
 
+@description('Config the user node pool as a spot instance')
+param nodePoolSpot bool = false
+
 @description('Allocate pod ips dynamically')
 param cniDynamicIpAllocation bool = false
 
@@ -1392,6 +1395,7 @@ module userNodePool '../bicep/aksagentpool.bicep' = if (!JustUseSystemPool){
     enableNodePublicIP: enableNodePublicIP
     osDiskSizeGB: osDiskSizeGB
     availabilityZones: availabilityZones
+    spotInstance: nodePoolSpot
   }
 }
 

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -223,6 +223,7 @@ export default function ({ defaults, tabValues, updateFn, featureFlag, invalidAr
                                 <MessageBar messageBarType={MessageBarType.error}>{getError(invalidArray, 'osDiskType')}</MessageBar>
                             }
                             <TextField label="VM SKU" onChange={(ev, val) => updateFn('vmSize', val)} required errorMessage={getError(invalidArray, 'vmSize')} value={cluster.vmSize} />
+                            <Checkbox checked={cluster.nodePoolSpot} onChange={(ev, val) => updateFn("nodePoolSpot", val)} disabled={cluster.SystemPoolType=='none'} onRenderLabel={() => <Text styles={{ root: { color: 'gray' } }}>Spot Instance</Text>} />
                             <ChoiceGroup
                                 onChange={(ev, { key }) => updateFn("osDiskType", key)}
                                 selectedKey={cluster.osDiskType}

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -40,6 +40,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osType !== defaults.cluster.osType && { osType: cluster.osType}),
     ...(cluster.osSKU !== defaults.cluster.osSKU && { osSKU: cluster.osSKU}),
+    ...(cluster.nodePoolSpot !== defaults.cluster.nodePoolSpot && { nodePoolSpot: cluster.nodePoolSpot}),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {
          custom_vnet: true,

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -40,7 +40,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     ...(cluster.autoscale && { agentCountMax: cluster.maxCount }),
     ...(cluster.osType !== defaults.cluster.osType && { osType: cluster.osType}),
     ...(cluster.osSKU !== defaults.cluster.osSKU && { osSKU: cluster.osSKU}),
-    ...(cluster.nodePoolSpot !== defaults.cluster.nodePoolSpot && { nodePoolSpot: cluster.nodePoolSpot}),
+    ...(cluster.SystemPoolType !== 'none' && cluster.nodePoolSpot !== defaults.cluster.nodePoolSpot && { nodePoolSpot: cluster.nodePoolSpot}),
     ...(cluster.osDiskType === "Managed" && { osDiskType: cluster.osDiskType, ...(cluster.osDiskSizeGB > 0 && { osDiskSizeGB: cluster.osDiskSizeGB }) }),
     ...(net.vnet_opt === "custom" && {
          custom_vnet: true,

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -117,6 +117,17 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
       ...(cluster.keyVaultKms === "public" && {keyVaultKmsCreate: true, keyVaultKmsOfficerRolePrincipalId: "$(az ad signed-in-user show --query id --out tsv)"}),
       ...(cluster.keyVaultKms === "byoprivate" && cluster.keyVaultKmsByoKeyId !== '' &&  cluster.keyVaultKmsByoRG !== '' && {keyVaultKmsByoKeyId: cluster.keyVaultKmsByoKeyId, keyVaultKmsByoRG: cluster.keyVaultKmsByoRG}),
     }),
+    ...(net.vnet_opt === "default" && net.aksOutboundTrafficType === 'natGateway' && {
+      ...(net.aksOutboundTrafficType !== defaults.net.aksOutboundTrafficType && {aksOutboundTrafficType: net.aksOutboundTrafficType}),
+      ...(net.natGwIpCount !== defaults.net.natGwIpCount && {natGwIpCount: net.natGwIpCount}),
+      ...(net.natGwIdleTimeout !== defaults.net.natGwIdleTimeout && {natGwIdleTimeout: net.natGwIdleTimeout})
+    }),
+    ...(net.vnet_opt === "custom" && net.aksOutboundTrafficType === 'natGateway' && {
+      ...({createNatGateway: true}),
+      ...(net.aksOutboundTrafficType !== defaults.net.aksOutboundTrafficType && {aksOutboundTrafficType: net.aksOutboundTrafficType}),
+      ...(net.natGwIpCount !== defaults.net.natGwIpCount && {natGwIpCount: net.natGwIpCount}),
+      ...(net.natGwIdleTimeout !== defaults.net.natGwIdleTimeout && {natGwIdleTimeout: net.natGwIdleTimeout})
+    }),
     ...(addons.csisecret !== "none" && { keyVaultAksCSI: true }),
     ...(addons.csisecret === 'akvNew' && { keyVaultCreate: true, ...(deploy.kvCertSecretRole && { keyVaultOfficerRolePrincipalId: "$(az ad signed-in-user show --query id --out tsv)"}) }),
     ...(addons.csisecret !== "none" && addons.keyVaultAksCSIPollInterval !== defaults.addons.keyVaultAksCSIPollInterval  && { keyVaultAksCSIPollInterval: addons.keyVaultAksCSIPollInterval }),
@@ -135,17 +146,6 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
   const preview_params = {
     ...(addons.registry === "Premium" && addons.acrUntaggedRetentionPolicyEnabled !== defaults.addons.acrUntaggedRetentionPolicyEnabled && { acrUntaggedRetentionPolicyEnabled: addons.acrUntaggedRetentionPolicyEnabled}),
     ...(addons.registry === "Premium" && addons.acrUntaggedRetentionPolicyEnabled && addons.acrUntaggedRetentionPolicy !== defaults.addons.acrUntaggedRetentionPolicy && { acrUntaggedRetentionPolicy: addons.acrUntaggedRetentionPolicy}),
-    ...(net.vnet_opt === "default" && net.aksOutboundTrafficType === 'natGateway' && {
-      ...(net.aksOutboundTrafficType !== defaults.net.aksOutboundTrafficType && {aksOutboundTrafficType: net.aksOutboundTrafficType}),
-      ...(net.natGwIpCount !== defaults.net.natGwIpCount && {natGwIpCount: net.natGwIpCount}),
-      ...(net.natGwIdleTimeout !== defaults.net.natGwIdleTimeout && {natGwIdleTimeout: net.natGwIdleTimeout})
-    }),
-    ...(net.vnet_opt === "custom" && net.aksOutboundTrafficType === 'natGateway' && {
-      ...({createNatGateway: true}),
-      ...(net.aksOutboundTrafficType !== defaults.net.aksOutboundTrafficType && {aksOutboundTrafficType: net.aksOutboundTrafficType}),
-      ...(net.natGwIpCount !== defaults.net.natGwIpCount && {natGwIpCount: net.natGwIpCount}),
-      ...(net.natGwIdleTimeout !== defaults.net.natGwIdleTimeout && {natGwIdleTimeout: net.natGwIdleTimeout})
-    }),
     ...(net.vnet_opt === "custom" && net.vnetprivateend && {
       ...(addons.registry !== "none" && {
         ...(addons.acrPrivatePool !== defaults.addons.acrPrivatePool && {acrPrivatePool: addons.acrPrivatePool}),

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -58,7 +58,8 @@
             "enableAzureRBAC": true,
             "aadgroupids": "",
             "availabilityZones": "no",
-            "DefenderForContainers" : false
+            "DefenderForContainers" : false,
+            "nodePoolSpot": false
         },
         "addons": {
             "logDataCap": 0,


### PR DESCRIPTION
## PR Summary

Adds support for VM Spot Instances for the user pool.

If using just the system pool then Spot Instances are not allowed, disabled in the UI and excluded from the deployment script generation.

Closes #610 

![image](https://github.com/Azure/AKS-Construction/assets/17914476/f60038f7-1615-47cb-863a-9ec9e6d94223)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
