### PR TITLE
Handle subscriptionId for bring your own private dns zone

### DIFF
--- a/bicep/dnsZoneRbac.bicep
+++ b/bicep/dnsZoneRbac.bicep
@@ -10,17 +10,19 @@ param vnetId string
 @description('The AAD identity to create the RBAC against')
 param principalId string
 
-var dnsZoneRg = !empty(dnsZoneId) ? split(dnsZoneId, '/')[4] : ''
-var dnsZoneName = !empty(dnsZoneId) ? split(dnsZoneId, '/')[8] : ''
-var isDnsZonePrivate = !empty(dnsZoneId) ? split(dnsZoneId, '/')[7] == 'privateDnsZones' : false
+var dnsZoneIdSegments = split(dnsZoneId, '/')
+var dnsZoneSubscriptionId = !empty(dnsZoneId) ? dnsZoneIdSegments[2] : ''
+var dnsZoneRg = !empty(dnsZoneId) ? dnsZoneIdSegments[4] : ''
+var dnsZoneName = !empty(dnsZoneId) ? dnsZoneIdSegments[8] : ''
+var isDnsZonePrivate = !empty(dnsZoneId) ? dnsZoneIdSegments[7] == 'privateDnsZones' : false
 
 module dnsZone './dnsZone.bicep' = if (!empty(dnsZoneId)) {
-  name: take('${deployment().name}-dns-${dnsZoneName}',64)
-  scope: resourceGroup(dnsZoneRg)
+  name: take('${deployment().name}-dns-${dnsZoneName}', 64)
+  scope: resourceGroup(dnsZoneSubscriptionId, dnsZoneRg)
   params: {
     dnsZoneName: dnsZoneName
     isPrivate: isDnsZonePrivate
-    vnetId : vnetId
+    vnetId: vnetId
     principalId: principalId
   }
 }


### PR DESCRIPTION
## PR Summary
In the `dnsZoneRbac` module, extract the subscriptionId from the private DNS zone id and use it in the scope of the `dnsZone` module. This makes possible to use a DNS zone already created in another subscription.

Fixes #615 

## PR Checklist

- [ x] PR has a meaningful title
- [ x] Summarized changes
- [ x] This PR is ready to merge and is not **Work in Progress**
- [x ] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
