### PR TITLE
Choosing a more secure option should not come with a warning - #621

### DIFF
--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -397,7 +397,7 @@ export default function ({ defaults, tabValues, updateFn, featureFlag, invalidAr
                     options={[
                         { key: 'none', text: 'Public IP with no IP restrictions' },
                         { key: 'whitelist', text: 'Create allowed IP ranges (defaults to IP address of machine running the script)' },
-                        { key: 'private', text: 'Private Cluster (WARNING: most complex to operate)' }
+                        { key: 'private', text: 'Private Cluster (Note: Best option, but most complex to operate)' }
 
                     ]}
                     onChange={(ev, { key }) => updateFn("apisecurity", key)}

--- a/helper/src/components/clusterTab.js
+++ b/helper/src/components/clusterTab.js
@@ -397,7 +397,7 @@ export default function ({ defaults, tabValues, updateFn, featureFlag, invalidAr
                     options={[
                         { key: 'none', text: 'Public IP with no IP restrictions' },
                         { key: 'whitelist', text: 'Create allowed IP ranges (defaults to IP address of machine running the script)' },
-                        { key: 'private', text: 'Private Cluster (Note: Best option, but most complex to operate)' }
+                        { key: 'private', text: 'Private Cluster (Most secure option for your apps, but requires most involved access management)' }
 
                     ]}
                     onChange={(ev, { key }) => updateFn("apisecurity", key)}

--- a/helper/src/configpresets/principals.json
+++ b/helper/src/configpresets/principals.json
@@ -291,7 +291,7 @@
                         "description": {
                             "title": "Best option for highly secure, regulated environments or sensitive data requirements.",
                             "titleWarning": {
-                                "description": "WARNING: most complex environment option to operate",
+                                "description": "Note: Best option, but most complex to operate",
                                 "MessageBarType": 5
                             },
                             "bulets": [

--- a/helper/src/configpresets/principals.json
+++ b/helper/src/configpresets/principals.json
@@ -291,7 +291,7 @@
                         "description": {
                             "title": "Best option for highly secure, regulated environments or sensitive data requirements.",
                             "titleWarning": {
-                                "description": "Note: Best option, but most complex to operate",
+                                "description": "Most secure option for your apps, but requires most involved access management",
                                 "MessageBarType": 5
                             },
                             "bulets": [


### PR DESCRIPTION
## PR Summary

Wanted more encouraging language for those that are choosing a private cluster. Changed two files clusterTab.js and principals.json

Fixes [#621](https://github.com/Azure/AKS-Construction/issues/621)
## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)

![image](https://github.com/Azure/AKS-Construction/assets/7284102/88b5e32e-8843-4c76-b2c7-03f0cdcc50af)
![image](https://github.com/Azure/AKS-Construction/assets/7284102/f4649088-9e69-430f-a5ff-d2abadd0378d)
