### PR TITLE
Updated default version of Kubernetes to 1.26.6

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -851,7 +851,7 @@ output ApplicationGatewayName string = deployAppGw ? appgw.name : ''
 param dnsPrefix string = '${resourceName}-dns'
 
 @description('Kubernetes Version')
-param kubernetesVersion string = '1.26.3'
+param kubernetesVersion string = '1.26.6'
 
 @description('Enable Azure AD integration on AKS')
 param enable_aad bool = false

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -851,7 +851,7 @@ output ApplicationGatewayName string = deployAppGw ? appgw.name : ''
 param dnsPrefix string = '${resourceName}-dns'
 
 @description('Kubernetes Version')
-param kubernetesVersion string = '1.25.6'
+param kubernetesVersion string = '1.26.3'
 
 @description('Enable Azure AD integration on AKS')
 param enable_aad bool = false

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -10,7 +10,7 @@
         "deploy": {
             "enableTelemetry": true,
             "managedNodeResourceGroup": "",
-            "kubernetesVersion": "1.25.6",
+            "kubernetesVersion": "1.26.3",
             "location": "WestEurope",
             "apiips": "",
             "demoapp": false,

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -10,7 +10,7 @@
         "deploy": {
             "enableTelemetry": true,
             "managedNodeResourceGroup": "",
-            "kubernetesVersion": "1.26.3",
+            "kubernetesVersion": "1.26.6",
             "location": "WestEurope",
             "apiips": "",
             "demoapp": false,

--- a/samples/SampleAppMain.json
+++ b/samples/SampleAppMain.json
@@ -551,7 +551,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.25.6",
+              "defaultValue": "1.26.3",
               "metadata": {
                 "description": "Kubernetes Version"
               }

--- a/samples/SampleAppMain.json
+++ b/samples/SampleAppMain.json
@@ -551,7 +551,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.26.3",
+              "defaultValue": "1.26.6",
               "metadata": {
                 "description": "Kubernetes Version"
               }

--- a/samples/SystemPresetExample.json
+++ b/samples/SystemPresetExample.json
@@ -493,7 +493,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.25.6",
+              "defaultValue": "1.26.3",
               "metadata": {
                 "description": "Kubernetes Version"
               }

--- a/samples/SystemPresetExample.json
+++ b/samples/SystemPresetExample.json
@@ -493,7 +493,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.26.3",
+              "defaultValue": "1.26.6",
               "metadata": {
                 "description": "Kubernetes Version"
               }

--- a/samples/shared-acr/main.json
+++ b/samples/shared-acr/main.json
@@ -519,7 +519,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.26.3",
+              "defaultValue": "1.26.6",
               "metadata": {
                 "description": "Kubernetes Version"
               }

--- a/samples/shared-acr/main.json
+++ b/samples/shared-acr/main.json
@@ -519,7 +519,7 @@
             },
             "kubernetesVersion": {
               "type": "string",
-              "defaultValue": "1.25.6",
+              "defaultValue": "1.26.3",
               "metadata": {
                 "description": "Kubernetes Version"
               }


### PR DESCRIPTION
...  following deprecation of 1.24 on AKS

## PR Summary

Updated all references to "1.25.6" to "1.26.3":
- bicep/main.bicep
- helper/src/config.json
- samples/SampleAppMain.json
- samples/SystemPresetExample.json
- samples/shared-acr/main.json

Fixes #626 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
