### PR TITLE
Added 'always display cluster get-credentials' checkbox option to helper

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -459,9 +459,7 @@ az role assignment create --role "Managed Identity Operator" --assignee-principa
 
             <Label>Always retrieve cluster credentials & login (interactive)</Label>
             <Stack.Item>
-              <Checkbox disabled={cluster.apisecurity === "private"} checked={addons.ingress === "nginx" || addons.ingress === "traefik" || addons.ingress === "contour" || deploy.getCreds} onChange={(ev, v) => updateFn("getCreds", v)} label="Always show the az aks get-credentials command to quickly connect to your new cluster" />
-              {/* <Checkbox checked={deploy.getCreds} onChange={(ev, v) => updateFn("getCreds", v)} label="Always show the az aks get-credentials command to quickly connect to your new cluster" /> */}
-              {/* <Checkbox onChange={(ev, v) => updateFn("getCreds", v)} label="Always show the az aks get-credentials command to quickly connect to your new cluster" /> */}
+              <Checkbox disabled={cluster.apisecurity === "private"} checked={addons.ingress === "nginx" || addons.ingress === "traefik" || addons.ingress === "contour" || deploy.getCreds} onChange={(ev, v) => updateFn("getCreds", v)} label="Always show the 'az aks get-credentials' command to quickly connect to your new cluster" />
             </Stack.Item>
 
             <Label>Telemetry</Label>

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -250,14 +250,14 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
   }).join('')
 
   const post_deployBASHcmd =  `\n\n# Deploy charts into cluster\n` +
-  (deploy.selectedTemplate === "local" ? `bash .${ cluster.apisecurity === "private" ? '' : '/postdeploy/scripts'}/postdeploy.sh ` : `curl -sL ${deployRelease.postBASH_url}  | bash -s -- `) +
-  (deploy.selectedTemplate === 'local' ? (cluster.apisecurity === "private" ? '-r .' : '') : `-r ${deployRelease.base_download_url}`) +
-  Object.keys(post_params).map(k => {
-    const val = post_params[k]
-    const targetVal = Array.isArray(val) ? JSON.stringify(JSON.stringify(val)) : val
-    return ` \\\n\t-p ${k}=${targetVal}`
-  }).join('')+
-  (!deploy.disablePreviews ? preview_post_deployBASHcmd : '')
+    (deploy.selectedTemplate === "local" ? `bash .${ cluster.apisecurity === "private" ? '' : '/postdeploy/scripts'}/postdeploy.sh ` : `curl -sL ${deployRelease.postBASH_url}  | bash -s -- `) +
+    (deploy.selectedTemplate === 'local' ? (cluster.apisecurity === "private" ? '-r .' : '') : `-r ${deployRelease.base_download_url}`) +
+    Object.keys(post_params).map(k => {
+      const val = post_params[k]
+      const targetVal = Array.isArray(val) ? JSON.stringify(JSON.stringify(val)) : val
+      return ` \\\n\t-p ${k}=${targetVal}`
+    }).join('')+
+    (!deploy.disablePreviews ? preview_post_deployBASHcmd : '')
 
   const getCredentials =
     '# Get credentials for your new AKS cluster & login (interactive)\n' +
@@ -294,14 +294,14 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     '\n\n' +
     (Object.keys(post_params).length >0 || (!deploy.disablePreviews && Object.keys(preview_post_params).length >0) ? post_deployBASHstr : '')
 
-    //Powershell (Remember to align any changes with Bash)
-    const preview_post_deployPScmd = Object.keys(preview_post_params).map(k => {
-      const val = preview_post_params[k]
-      const targetVal = Array.isArray(val) ? JSON.stringify(JSON.stringify(val)) : val
-      return ` \`\n\t-${k} ${targetVal}`
-    }).join('')
+  //Powershell (Remember to align any changes with Bash)
+  const preview_post_deployPScmd = Object.keys(preview_post_params).map(k => {
+    const val = preview_post_params[k]
+    const targetVal = Array.isArray(val) ? JSON.stringify(JSON.stringify(val)) : val
+    return ` \`\n\t-${k} ${targetVal}`
+  }).join('')
 
-    const post_deployPScmd =  `\n\n# Deploy charts into cluster\n` +
+  const post_deployPScmd =  `\n\n# Deploy charts into cluster\n` +
     (deploy.selectedTemplate === "local" ? ` .${ cluster.apisecurity === "private" ? '' : '/postdeploy/scripts'}/postdeploy.ps1 ` : `& $([scriptblock]::Create((New-Object Net.WebClient).DownloadString("${deployRelease.postPS_url}")))`) +
     (deploy.selectedTemplate === 'local' ? (cluster.apisecurity === "private" ? '-r .' : '') : ` -releace_version="${deployRelease.base_download_url}"`) +
     Object.keys(post_params).map(k => {
@@ -316,7 +316,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
     :
     privateCluster
 
-    const deployPScmd =
+  const deployPScmd =
     `# Create Resource Group\n` +
     `az group create -l ${deploy.location} -n ${deploy.rg}\n\n` + networkWatcher +
     `# Deploy template with in-line parameters\n` +

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -28,7 +28,8 @@
             "githubrepo": "",
             "githubrepobranch": "main",
             "deployItemKey": "deployArmCli",
-            "workloadDeployCommands" : []
+            "workloadDeployCommands" : [],
+            "getCreds" : true
         },
         "cluster": {
             "keyVaultKmsByoRG": "",


### PR DESCRIPTION
## PR Summary

- Added "Always show the 'az aks get-credentials' command to quickly connect to your new cluster" checkbox to the helper
- Set this option to default to "true" (i.e. on)
- Refactored some of the post-deploy logic to separate the connection command from the post-deploy commands
- Added logic for private clusters (which don't need a cluster connection string as we use the invoke command instead)
- Fixed indentation on some adjacent code

Fixes #614 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)

Screenshot:

<img width="750" alt="Screenshot 2023-08-08 111957" src="https://github.com/Azure/AKS-Construction/assets/6115202/1cd72858-67bd-497c-ba52-9946868d3caf">
