### PR TITLE
Update helper-export-az-commands.spec.js

### DIFF
--- a/helper/.playwrighttests/helper-export-az-commands.spec.js
+++ b/helper/.playwrighttests/helper-export-az-commands.spec.js
@@ -5,7 +5,7 @@ const chk = '+ label > .ms-Checkbox-checkbox > .ms-Checkbox-checkmark' //fluentu
 
 test('test', async ({ page }) => {
 
-  await page.goto('http://localhost:3000/AKS-Construction');
+  await page.goto('http://localhost:3000/AKS-Construction?deploy.getCredentials=false');
 
   //Select the Private Cluster preset
   const privateClusterPresetCheckboxSelector='[data-testid="stackops"] > .ms-DocumentCard:nth-child(3) > .ms-DocumentCardDetails > .ms-Checkbox > .ms-Checkbox-label > .ms-Checkbox-checkbox > .ms-Checkbox-checkmark';


### PR DESCRIPTION
## PR Summary

Resolves the issue (https://github.com/Azure/AKS-Construction/issues/641) where the release fails due to playwright tests after we introduced az get credentials when the param deploy.getCredentials is set to true.

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [X] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
