### PR TITLE
Updated variable names to prevent case clash

### DIFF
--- a/bicep/network.bicep
+++ b/bicep/network.bicep
@@ -189,13 +189,13 @@ var aks_podSubnet =  {
 }
 
 var aks_subnet = networkSecurityGroups ? union(aks_baseSubnet, nsgAks.outputs.nsgSubnetObj) : aks_baseSubnet
-var aks_podsubnet = networkSecurityGroups ? union(aks_podSubnet, nsgAks.outputs.nsgSubnetObj) : aks_podSubnet
+var aks_finalPodSubnet = networkSecurityGroups ? union(aks_podSubnet, nsgAks.outputs.nsgSubnetObj) : aks_podSubnet
 
 
 
 var subnets = union(
   array(aks_subnet),
-  cniDynamicIpAllocation ? array(aks_podsubnet) : [],
+  cniDynamicIpAllocation ? array(aks_finalPodSubnet) : [],
   azureFirewalls ? array(fw_subnet) : [],
   privateLinks ? array(private_link_subnet) : [],
   acrPrivatePool ? array(acrpool_subnet) : [],


### PR DESCRIPTION
## PR Summary

Changed the name of `aks_podsubnet` variable to `aks_finalPodSubnet` to prevent clash with `aks_podSubnet` variable (notice case difference)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
