### PR TITLE
Fixing inline code snippets so that they show up in dark theme

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -599,7 +599,7 @@ gh secret set --repo ${deploy.githubrepo} USER_OBJECT_ID -b $spId
 <Text>* Requires <Link target="_gh" href="https://github.com/cli/cli">GitHub CLI</Link>, or execute in the <Link target="_cs" href="http://shell.azure.com/">Azure Cloud Shell (where it is pre-installed)</Link>.</Text>
 <Separator></Separator>
 
-            <Text style={{marginTop: '20px'}}>Add the following code to a new file in your repos <code style={{ "background-color": "#e6e6e6"}}>.github/workflows</code> folder, this will call the AKS-Construction reusable workflow.  NOTE: This example creates a manually triggered Action</Text>
+            <Text style={{marginTop: '20px'}}>Add the following code to a new file in your repos <code>.github/workflows</code> folder, this will call the AKS-Construction reusable workflow.  NOTE: This example creates a manually triggered Action</Text>
             <CodeBlock testId={'deploy-github-actions'} lang="github actions"  deploycmd={`name: Deploy AKS-Construction
 
 on:

--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -599,7 +599,7 @@ gh secret set --repo ${deploy.githubrepo} USER_OBJECT_ID -b $spId
 <Text>* Requires <Link target="_gh" href="https://github.com/cli/cli">GitHub CLI</Link>, or execute in the <Link target="_cs" href="http://shell.azure.com/">Azure Cloud Shell (where it is pre-installed)</Link>.</Text>
 <Separator></Separator>
 
-            <Text style={{marginTop: '20px'}}>Add the following code to a new file in your repos <code>.github/workflows</code> folder, this will call the AKS-Construction reusable workflow.  NOTE: This example creates a manually triggered Action</Text>
+            <Text style={{marginTop: '20px'}}>Add the following code to a new file in your repos <code style={{ "background-color": "#e6e6e6"}}>.github/workflows</code> folder, this will call the AKS-Construction reusable workflow.  NOTE: This example creates a manually triggered Action</Text>
             <CodeBlock testId={'deploy-github-actions'} lang="github actions"  deploycmd={`name: Deploy AKS-Construction
 
 on:

--- a/helper/src/index.css
+++ b/helper/src/index.css
@@ -87,3 +87,12 @@ code {
 a {
     color: #9370DB !important;
 }
+
+
+span code{
+    color: #171717;
+    background-color: #e6e6e6;
+    line-height: 130%;
+    direction: ltr;
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;
+}

--- a/helper/src/index.css
+++ b/helper/src/index.css
@@ -72,7 +72,6 @@ pre {
 
 code {
     color: #171717;
-    background-color: #e6e6e6;
     line-height: 130%;
     direction: ltr;
     font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;

--- a/helper/src/index.css
+++ b/helper/src/index.css
@@ -72,6 +72,7 @@ pre {
 
 code {
     color: #171717;
+    background-color: #e6e6e6;
     line-height: 130%;
     direction: ltr;
     font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;


### PR DESCRIPTION
## PR Summary

Adding in a grey background colour to the code element so that regardless of whether the user is in light or dark theme there is a contrast in the text colour to the background so that it is visible in both themes.

Below are the screenshots of the fixed UI.

![image](https://github.com/Azure/AKS-Construction/assets/73177811/678e15e1-fe2f-4bcc-bc89-900fbed2dff0)

![image](https://github.com/Azure/AKS-Construction/assets/73177811/39ae2d1d-33f2-4733-93d4-1dea64313d74)

Screenshot below is how it used to appear in dark theme. The ".github/workflows" is clearly not visible in dark theme.

![image](https://github.com/Azure/AKS-Construction/assets/73177811/f58cc86f-fbe3-46df-b99c-1423f57d3d35)

In the light theme the code snippets will now have a grey background surrounding the text. In my opinion this is good as most code snippets on the web use a background colour to differentiate the snippet from the rest of the text. Screenshot below is the original light theme without the changes of this PR. It is difficult to tell that the code snippet is different to any of the other surrounding text.

![image](https://github.com/Azure/AKS-Construction/assets/73177811/9313a618-374f-4863-943b-7f29ef40ecf8)


Link to the original issue: https://github.com/Azure/AKS-Construction/issues/629




## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
