### PR TITLE
Set default osDiskSizeGB based on OS Type

### DIFF
--- a/bicep/aksagentpool.bicep
+++ b/bicep/aksagentpool.bicep
@@ -51,6 +51,9 @@ param autoTaintWindows bool = false
 
 var taints = autoTaintWindows ? union(nodeTaints, ['sku=Windows:NoSchedule']) : nodeTaints
 
+// Default OS Disk Size in GB for Linux is 30, for Windows is 100
+var defaultOsDiskSizeGB = osType == 'Linux' ? 30 : 100
+
 resource aks 'Microsoft.ContainerService/managedClusters@2021-10-01' existing = {
   name: AksName
 }
@@ -68,7 +71,7 @@ resource userNodepool 'Microsoft.ContainerService/managedClusters/agentPools@202
     availabilityZones: !empty(availabilityZones) ? availabilityZones : null
     osDiskType: osDiskType
     osSKU: osSKU
-    osDiskSizeGB: osDiskSizeGB
+    osDiskSizeGB: osDiskSizeGB == 0 ? defaultOsDiskSizeGB : osDiskSizeGB
     osType: osType
     maxPods: maxPods
     type: 'VirtualMachineScaleSets'

--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1375,6 +1375,9 @@ param osSKU string = 'Ubuntu'
 
 var poolName = osType == 'Linux' ? nodePoolName : take(nodePoolName, 6)
 
+// Default OS Disk Size in GB for Linux is 30, for Windows is 100
+var defaultOsDiskSizeGB = osType == 'Linux' ? 30 : 100
+
 module userNodePool '../bicep/aksagentpool.bicep' = if (!JustUseSystemPool){
   name: take('${deployment().name}-userNodePool',64)
   params: {
@@ -1390,7 +1393,7 @@ module userNodePool '../bicep/aksagentpool.bicep' = if (!JustUseSystemPool){
     osType: osType
     osSKU: osSKU
     enableNodePublicIP: enableNodePublicIP
-    osDiskSizeGB: osDiskSizeGB
+    osDiskSizeGB: osDiskSizeGB == 0 ? defaultOsDiskSizeGB : osDiskSizeGB
     availabilityZones: availabilityZones
   }
 }

--- a/helper/src/config.json
+++ b/helper/src/config.json
@@ -50,7 +50,7 @@
             "maxCount": 20,
             "computeType": "gp",
             "vmSize": "Standard_DS3_v2",
-            "osDiskSizeGB": 0,
+            "osDiskSizeGB": 30,
             "osDiskType": "Ephemeral",
             "enable_aad": true,
             "AksDisableLocalAccounts": false,


### PR DESCRIPTION
## PR Summary

Addressing the Issue https://github.com/Azure/AKS-Construction/issues/612, this PR sets the default for osDiskSizeGB for node pools based on OS Type:
- for Linux, defaults to 30Gb
- for Windows, defaults to 100Gb

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [X] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
