### PR TITLE
Added error message when App GW and CNI Overlay are selected

### DIFF
--- a/helper/src/components/addonsTab.js
+++ b/helper/src/components/addonsTab.js
@@ -91,6 +91,9 @@ export default function ({ tabValues, updateFn, featureFlag, invalidArray,showPr
                 <Label required={true}>
                     Ingress Controllers: Securely expose your applications via Layer 7 HTTP(S) proxies
                 </Label>
+                {hasError(invalidArray, 'ingressControllers') &&
+                    <MessageBar messageBarType={MessageBarType.error}>{getError(invalidArray, 'ingressControllers')}</MessageBar>
+                }
                 {cluster.osType==='Windows' && addons.ingress !== 'none' &&
                     <MessageBar styles={{ root: { marginTop: '20px', marginLeft: '50px', width: '700px' } }} messageBarType={MessageBarType.warning}>
                         Please Note: If you're using Windows Nodes not all Ingress Controllers will support this OS, please check the Ingress Controller documentation and change the OS or Ingress Controller as required.

--- a/helper/src/components/networkTab.js
+++ b/helper/src/components/networkTab.js
@@ -81,6 +81,9 @@ export default function NetworkTab ({ defaults, tabValues, updateFn, invalidArra
 
             <Stack.Item>
                 <Label>CNI Features</Label>
+                {hasError(invalidArray, 'cniFeatures') &&
+                    <MessageBar messageBarType={MessageBarType.error}>{getError(invalidArray, 'cniFeatures')}</MessageBar>
+                }
                 <Stack horizontal tokens={{ childrenGap: 15 }} >
                     <Stack.Item>
                         <MessageBar messageBarType={MessageBarType.info}>Dynamic IP allocation separates node IP's and Pod IP's by subnet allowing dynamic allocation of Pod IPs <a target="_new" href="https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni#dynamic-allocation-of-ips-and-enhanced-subnet-support">docs</a> </MessageBar>

--- a/helper/src/components/portalnav.js
+++ b/helper/src/components/portalnav.js
@@ -412,6 +412,8 @@ export default function PortalNav({ config }) {
   invalidFn('net', 'vnetAddressPrefix', !isCidrValid(net.vnetAddressPrefix), invalidCidrMessage)
   invalidFn('net', 'vnetAksSubnetAddressPrefix', !isCidrValid(net.vnetAksSubnetAddressPrefix), invalidCidrMessage)
   invalidFn('net', 'networkPlugin', net.networkPlugin === "kubenet" && cluster.osType === "Windows" , "Windows nodepools do not support kubenet networking")
+  invalidFn('net', 'cniFeatures', addons.ingress === "appgw" && net.networkPluginMode === true, "CNI Overlay does not support the Azure Application Gateway ingress controller. Please select an alternative ingress controller on the Addon Details tab")
+  invalidFn('addons', 'ingressControllers', addons.ingress === "appgw" && net.networkPluginMode === true, "CNI Overlay does not support the Azure Application Gateway ingress controller. Please select an alternative ingress controller to continue")
   invalidFn('addons', 'networkPolicy', (!net.ebpfDataplane && addons.networkPolicy === "cilium") || (net.ebpfDataplane && (addons.networkPolicy === "calico" || addons.networkPolicy === "azure")), net.ebpfDataplane ? "Cilium epbf backplane is incompatible with Azure NPM and Calico" : "Cilium network policy requires the CNI Cilium epbf to be enabled")
   invalidFn('deploy', 'apiips', cluster.apisecurity === 'whitelist' && deploy.apiips.length < 7, 'Enter an IP/CIDR, or select \'Public IP with no IP restrictions\' in the \'Cluster API Server Security\' section of the \'Cluster Details\' tab')
   invalidFn('deploy', 'clusterName', !deploy.clusterName || deploy.clusterName.match(/^[a-z0-9][_\-a-z0-9]+[a-z0-9]$/i) === null || deploy.clusterName.length > 19, 'Enter valid cluster name')


### PR DESCRIPTION
## PR Summary

Added error messages on Addon Details and Networking Details tabs when Azure Application Gateway ingress controller and Azure CNI Overlay Networking are selected. This resolves #653 and unblocks #633.

Screenshots below:

![image](https://github.com/Azure/AKS-Construction/assets/6115202/da4bd97a-2f55-49fe-bf01-34a7fc8f8257)
![image](https://github.com/Azure/AKS-Construction/assets/6115202/2bc0b7fd-f893-4c87-adbe-eb8aecfe13fe)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [x] Screenshot of UI changes (if PR includes UI changes)
