### PR TITLE
Allow usage of predefined system nodepools and custompreset with JustUseSystemNodepool.

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -1185,7 +1185,7 @@ var systemPoolBase = {
   ]
 }
 
-var agentPoolProfiles = JustUseSystemPool ? array(systemPoolBase) : concat(array(union(systemPoolBase, SystemPoolType=='Custom' && SystemPoolCustomPreset != {} ? SystemPoolCustomPreset : systemPoolPresets[SystemPoolType])))
+var agentPoolProfiles = concat(array(union(systemPoolBase, SystemPoolType=='Custom' && SystemPoolCustomPreset != {} ? SystemPoolCustomPreset : systemPoolPresets[SystemPoolType])))
 
 output userNodePoolName string = nodePoolName
 output systemNodePoolName string = JustUseSystemPool ? nodePoolName : 'npsystem'


### PR DESCRIPTION
Resolve #673 
## PR Summary

bugfix: Allow usage of predefined system nodepools and custompreset with JustUseSystemNodepool param set to true.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [x] Link to a filed issue
- [ ] Screenshot of UI changes (if PR includes UI changes)
