### PR TITLE
Fix release_version postdeploy param typo

### DIFF
--- a/helper/src/components/deployTab.js
+++ b/helper/src/components/deployTab.js
@@ -309,7 +309,7 @@ export default function DeployTab({ defaults, updateFn, tabValues, invalidArray,
 
   const post_deployPScmd =  `\n\n# Deploy charts into cluster\n` +
     (deploy.selectedTemplate === "local" ? ` .${ cluster.apisecurity === "private" ? '' : '/postdeploy/scripts'}/postdeploy.ps1 ` : `& $([scriptblock]::Create((New-Object Net.WebClient).DownloadString("${deployRelease.postPS_url}")))`) +
-    (deploy.selectedTemplate === 'local' ? (cluster.apisecurity === "private" ? '-r .' : '') : ` -releace_version="${deployRelease.base_download_url}"`) +
+    (deploy.selectedTemplate === 'local' ? (cluster.apisecurity === "private" ? '-r .' : '') : ` -release_version="${deployRelease.base_download_url}"`) +
     Object.keys(post_params).map(k => {
       const val = post_params[k]
       const targetVal = Array.isArray(val) ? JSON.stringify(JSON.stringify(val)) : val


### PR DESCRIPTION
## PR Summary

The powershell script generated contains a typo - "relea**c**e_version" should be "relea**s**e_version".  This PR corrects that.   

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [X] This PR is ready to merge and is not **Work in Progress**
- [X] Link to a filed issue (#698) 
- [ ] **(N/A)** Screenshot of UI changes (if PR includes UI changes)
