### PR TITLE
Update to latest stable version of PSRule

### DIFF
--- a/.github/workflows/regressionparams.yml
+++ b/.github/workflows/regressionparams.yml
@@ -152,7 +152,7 @@ jobs:
       # https://azure.github.io/PSRule.Rules.Azure/
       - name: PSRule - Analyze Azure parameter file
         if: steps.paramfile.outputs.DOPSRULE == 'true'
-        uses: Microsoft/ps-rule@main
+        uses: microsoft/ps-rule@v2.9.0
         continue-on-error: true #Setting this whilst PSRule gets bedded in, in this project
         with:
           modules: 'PSRule.Rules.Azure'
@@ -162,7 +162,7 @@ jobs:
 
       - name: PSRule - Analyze Azure parameter file including Preview feature rulesets
         if: steps.paramfile.outputs.DOPSRULE == 'true'
-        uses: Microsoft/ps-rule@main
+        uses: microsoft/ps-rule@v2.9.0
         continue-on-error: true #Preview feature checking means we need to suppress errors
         with:
           modules: 'PSRule.Rules.Azure'


### PR DESCRIPTION
# PR Summary

- Switch to using the latest stable version of PSRule in CI pipeline.

---

👋 Hi, we're making changes the `microsoft/ps-rule` action preparing for the next major release which will introduce breaking changes.

We noticed that you are using an unpinned configuration `@main` which is not recommended. Please feel free to close this PR if this is intended, however note your pipeline may be broken by upcoming changes.

For recommendations on how to pin to a specific version, see the [documentation](https://github.com/microsoft/ps-rule).